### PR TITLE
improving NoJunitAssertRuleTestTest to take into account Junit 5 asserts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,13 @@
             <version>3.5.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.4.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
@@ -13,7 +13,9 @@ import java.nio.file.Paths;
  */
 public class ArchUtils {
 
-  private static final String JUNIT_ASSERT_PACKAGE_NAME = "org.junit.Assert";
+  private static final String JUNIT4_ASSERT_PACKAGE_NAME = "org.junit.Assert";
+  private static final String JUNIT5_ASSERT_PACKAGE_NAME = "org.junit.jupiter.api.Assertions";
+
   public static final String NO_JUNIT_ASSERT_DESCRIPTION = "not use Junit assertions";
 
   public static final String TEST_CLASSES_FOLDER = "/test-classes";
@@ -42,6 +44,9 @@ public class ArchUtils {
   }
 
   public static boolean isJunitAssert(JavaClass javaClass) {
-    return (JUNIT_ASSERT_PACKAGE_NAME).equals(new StringBuilder().append(javaClass.getPackageName()).append(PACKAGE_SEPARATOR).append(javaClass.getSimpleName()).toString());
+
+    String packageNameToCheck=new StringBuilder().append(javaClass.getPackageName()).append(PACKAGE_SEPARATOR).append(javaClass.getSimpleName()).toString();
+
+    return JUNIT4_ASSERT_PACKAGE_NAME.equals(packageNameToCheck) || JUNIT5_ASSERT_PACKAGE_NAME.equals(packageNameToCheck);
   }
 }

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoJunitAssertRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoJunitAssertRuleTestTest.java
@@ -1,6 +1,7 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithJunitAsserts;
+import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithJunit4Asserts;
+import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithJunit5Asserts;
 import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithOutJunitAsserts;
 import com.societegenerale.commons.plugin.utils.ArchUtils;
 import com.tngtech.archunit.core.domain.JavaClasses;
@@ -12,7 +13,8 @@ import static org.assertj.core.api.Assertions.*;
 
 public class NoJunitAssertRuleTestTest {
 
-    private JavaClasses testClassWithJunitAsserts = new ClassFileImporter().importClasses(TestClassWithJunitAsserts.class);
+    private JavaClasses testClassWithJunit4Asserts = new ClassFileImporter().importClasses(TestClassWithJunit4Asserts.class);
+    private JavaClasses testClassWithJunit5Asserts = new ClassFileImporter().importClasses(TestClassWithJunit5Asserts.class);
     private JavaClasses  tesClassesWithoutJunitAsserts = new ClassFileImporter().importClasses(TestClassWithOutJunitAsserts.class);
 
     @Test
@@ -24,11 +26,11 @@ public class NoJunitAssertRuleTestTest {
 
 
     @Test
-    public void shouldThrowViolations(){
+    public void shouldThrowForJunit4Violations(){
 
         Throwable validationExceptionThrown = catchThrowable(() -> {
 
-            classes().should(NoJunitAssertRuleTest.notUseJunitAssertRule()).check(testClassWithJunitAsserts);
+            classes().should(NoJunitAssertRuleTest.notUseJunitAssertRule()).check(testClassWithJunit4Asserts);
 
         });
 
@@ -38,7 +40,26 @@ public class NoJunitAssertRuleTestTest {
                 .hasMessageContaining("calls method <org.junit.Assert.fail(java.lang.String)");
 
         assertThat(validationExceptionThrown).hasMessageStartingWith("Architecture Violation")
-                .hasMessageContaining(TestClassWithJunitAsserts.class.getName())
+                .hasMessageContaining(TestClassWithJunit4Asserts.class.getName())
+                .hasMessageContaining(ArchUtils.NO_JUNIT_ASSERT_DESCRIPTION);
+    }
+
+    @Test
+    public void shouldThrowForJunit5Violations(){
+
+        Throwable validationExceptionThrown = catchThrowable(() -> {
+
+            classes().should(NoJunitAssertRuleTest.notUseJunitAssertRule()).check(testClassWithJunit5Asserts);
+
+        });
+
+        assertThat(validationExceptionThrown).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("was violated (2 times)")
+                .hasMessageContaining("calls method <org.junit.jupiter.api.Assertions.assertEquals(java.lang.Object, java.lang.Object)")
+                .hasMessageContaining("org.junit.jupiter.api.Assertions.fail(java.lang.String)");
+
+        assertThat(validationExceptionThrown).hasMessageStartingWith("Architecture Violation")
+                .hasMessageContaining(TestClassWithJunit5Asserts.class.getName())
                 .hasMessageContaining(ArchUtils.NO_JUNIT_ASSERT_DESCRIPTION);
     }
 

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/TestClassWithJunit4Asserts.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/TestClassWithJunit4Asserts.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class TestClassWithJunitAsserts {
+public class TestClassWithJunit4Asserts {
 
     @Test
     public void someTest() {

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/TestClassWithJunit5Asserts.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/TestClassWithJunit5Asserts.java
@@ -1,0 +1,19 @@
+package com.societegenerale.commons.plugin.rules.classesForTests;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestClassWithJunit5Asserts {
+
+    @Test
+    public void someTest() {
+
+        assertEquals(true,true);
+
+        fail("it failed ");
+
+    }
+}


### PR DESCRIPTION
## Summary

NoJunitAssertRuleTestTest is working only for Junit 4 asserts. more and more people use Junit 5, so the rule should also apply

## Details

Replicated the Junit 4 and adapted it for Junit 5

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR

