### PR TITLE
Add validation for checks, support ArchTest methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ If you need to add a rule that is specific to a project, just add a regular Arch
 
 ### Add a rule, and share it across projects
 
-To be able to share a rule, you'll need to package it in a jar. Add the jar to your classpath (by mentioning it as a plugin's dependency for instance), and then mention the ```<rule>``` with its fully qualified name the ```<rules>``` block, so that ArchUnit Maven plugin can instantiate it and run it. 
+You can share custom rules by packaging the respective classes containing the rules in a jar.
+Such classes can either contain fields of type `ArchRule` or methods taking a single parameter of type
+`JavaClasses` (compare JUnit support at https://www.archunit.org/userguide/html/000_Index.html#_junit_4_5_support).
+The classes those rules will be checked against are configured within the plugin.
+Add the jar containing your classes to your classpath (by mentioning it as a plugin's dependency for instance), 
+and then mention the ```<rule>``` with its fully qualified name the ```<rules>``` block, 
+so that ArchUnit Maven plugin can instantiate it and run it. 
 
 So your config would become something like :
 
@@ -77,18 +83,20 @@ So your config would become something like :
        <preConfiguredRules>
             <rule>com.societegenerale.commons.plugin.rules.NoJunitAssertRuleTest</rule>
        </preConfiguredRules>
-       <!-- ... and a custom one, coming from a a package I declare as dependency in the plugin-->
+       <!-- ... and a custom one, coming from a dependency of the plugin-->
        <configurableRules>
-       	<configurableRule>
-       		<rule>com.mycompany.rules.CustomArchRule</rule>
-       		<applyOn>
-       			<packageName>com.myproject.mypackage</packageName>
-       			<scope>test</scope>
-       		</applyOn>
-       		<checks>
-       			<check>customArchRule</check>
-       		</checks>
-       	</configurableRule>
+       	 <configurableRule>
+       	 	<rule>com.mycompany.rules.CustomArchRule</rule>
+       	 	<applyOn>
+       	 		<packageName>com.myproject.mypackage</packageName>
+       	 		<scope>test</scope>
+       	 	</applyOn>
+            <!-- if the checks block is missing, all rules will be evaluated -->
+       	 	<checks>
+       	 	    <!-- otherwise you can specify either field or method names here -->
+       	 		<check>customArchRule</check>
+       	 	</checks>
+       	 </configurableRule>
        </configurableRules>
     </rules>
   </configuration>
@@ -102,6 +110,7 @@ So your config would become something like :
   </executions>
   <dependencies>
     <dependency>
+        <!-- dependency contains com.mycompany.rules.CustomArchRule -->
         <groupId>com.myCompany</groupId>
         <artifactId>custom-quality-rules</artifactId>
         <version>1.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.tngtech.junit.dataprovider</groupId>
+            <artifactId>junit4-dataprovider</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
+++ b/src/main/java/com/societegenerale/commons/plugin/model/ConfigurableRule.java
@@ -2,6 +2,7 @@ package com.societegenerale.commons.plugin.model;
 
 import org.apache.maven.plugins.annotations.Parameter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ConfigurableRule {
@@ -13,7 +14,7 @@ public class ConfigurableRule {
   private ApplyOn applyOn;
 
   @Parameter(property ="checks")
-  private List<String> checks;
+  private List<String> checks = new ArrayList<>();
 
   public List<String> getChecks() {
     return checks;

--- a/src/main/java/com/societegenerale/commons/plugin/rules/NoJavaUtilDateRuleTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/NoJavaUtilDateRuleTest.java
@@ -41,7 +41,7 @@ public class NoJavaUtilDateRuleTest implements ArchRuleTest {
 
 	protected static ArchCondition<JavaClass> notUseJavaUtilDate() {
 
-		return new ArchCondition<JavaClass>("not use Java Util Date ") {
+		return new ArchCondition<JavaClass>("not use Java Util Date") {
 			@Override
 			public void check(JavaClass item, ConditionEvents events) {
 

--- a/src/main/java/com/societegenerale/commons/plugin/rules/NoPowerMockRuleTest.java
+++ b/src/main/java/com/societegenerale/commons/plugin/rules/NoPowerMockRuleTest.java
@@ -26,7 +26,7 @@ public class NoPowerMockRuleTest implements ArchRuleTest {
 
     public static ArchCondition<JavaClass> notUsePowerMock() {
 
-        return new ArchCondition<JavaClass>(" not use Powermock ") {
+        return new ArchCondition<JavaClass>("not use Powermock") {
 
             @Override
             @SuppressWarnings("squid:S1166")

--- a/src/main/java/com/societegenerale/commons/plugin/service/IllegalChecksConfigurationException.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/IllegalChecksConfigurationException.java
@@ -1,0 +1,9 @@
+package com.societegenerale.commons.plugin.service;
+
+import java.util.Set;
+
+class IllegalChecksConfigurationException extends RuntimeException {
+    IllegalChecksConfigurationException(Class<?> rulesLocation, Set<String> illegalChecks) {
+        super(String.format("The following configured checks are not present within %s: %s", rulesLocation.getName(), illegalChecks));
+    }
+}

--- a/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java
@@ -38,11 +38,21 @@ class InvokableRules {
 
         Set<Field> allFieldsWhichAreArchRules = getAllFieldsWhichAreArchRules(rulesLocation.getDeclaredFields());
         Set<Method> allMethodsWhichReturnAnArchCondition = getAllMethodsWhichReturnAnArchCondition(rulesLocation.getDeclaredMethods());
+        validateRuleChecks(Sets.union(allMethodsWhichReturnAnArchCondition, allFieldsWhichAreArchRules), ruleChecks);
 
         Predicate<String> isChosenCheck = ruleChecks.isEmpty() ? check -> true : ruleChecks::contains;
 
         archRuleFields = filterNames(allFieldsWhichAreArchRules, isChosenCheck);
         archConditionReturningMethods = filterNames(allMethodsWhichReturnAnArchCondition, isChosenCheck);
+    }
+
+    private void validateRuleChecks(Set<? extends Member> allFieldsAndMethods, Collection<String> ruleChecks) {
+        Set<String> allFieldAndMethodNames = allFieldsAndMethods.stream().map(Member::getName).collect(toSet());
+        Set<String> illegalChecks = Sets.difference(ImmutableSet.copyOf(ruleChecks), allFieldAndMethodNames);
+
+        if (!illegalChecks.isEmpty()) {
+            throw new IllegalChecksConfigurationException(rulesLocation, illegalChecks);
+        }
     }
 
     private <M extends Member> Set<M> filterNames(Set<M> members, Predicate<String> namePredicate) {

--- a/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/InvokableRules.java
@@ -1,0 +1,108 @@
+package com.societegenerale.commons.plugin.service;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.societegenerale.commons.plugin.utils.ReflectionUtils.getValue;
+import static com.societegenerale.commons.plugin.utils.ReflectionUtils.invoke;
+import static com.societegenerale.commons.plugin.utils.ReflectionUtils.loadClassWithContextClassLoader;
+import static com.societegenerale.commons.plugin.utils.ReflectionUtils.newInstance;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static java.lang.System.lineSeparator;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+
+class InvokableRules {
+    private final Class<?> rulesLocation;
+    private final Set<Field> archRuleFields;
+    private final Set<Method> archConditionReturningMethods;
+
+    private InvokableRules(String rulesClassName, List<String> ruleChecks) {
+
+        rulesLocation = loadClassWithContextClassLoader(rulesClassName);
+
+        Set<Field> allFieldsWhichAreArchRules = getAllFieldsWhichAreArchRules(rulesLocation.getDeclaredFields());
+        Set<Method> allMethodsWhichReturnAnArchCondition = getAllMethodsWhichReturnAnArchCondition(rulesLocation.getDeclaredMethods());
+
+        Predicate<String> isChosenCheck = ruleChecks.isEmpty() ? check -> true : ruleChecks::contains;
+
+        archRuleFields = filterNames(allFieldsWhichAreArchRules, isChosenCheck);
+        archConditionReturningMethods = filterNames(allMethodsWhichReturnAnArchCondition, isChosenCheck);
+    }
+
+    private <M extends Member> Set<M> filterNames(Set<M> members, Predicate<String> namePredicate) {
+        return members.stream()
+                .filter(member -> namePredicate.test(member.getName()))
+                .collect(toSet());
+    }
+
+    private Set<Method> getAllMethodsWhichReturnAnArchCondition(Method[] methods) {
+        return stream(methods)
+                .filter(m -> ArchCondition.class.isAssignableFrom(m.getReturnType()))
+                .collect(toSet());
+    }
+
+    private Set<Field> getAllFieldsWhichAreArchRules(Field[] fields) {
+        return stream(fields)
+                .filter(f -> ArchRule.class.isAssignableFrom(f.getType()))
+                .collect(toSet());
+    }
+
+    InvocationResult invokeOn(JavaClasses importedClasses) {
+
+        Object instance = newInstance(rulesLocation);
+
+        InvocationResult result = new InvocationResult();
+        for (Method method : archConditionReturningMethods) {
+            ArchCondition<JavaClass> condition = invoke(method, instance);
+            checkForFailure(() -> classes().should(condition).check(importedClasses))
+                    .ifPresent(result::add);
+        }
+        for (Field field : archRuleFields) {
+            ArchRule rule = getValue(field, instance);
+            checkForFailure(() -> rule.check(importedClasses))
+                    .ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private Optional<String> checkForFailure(Runnable runnable) {
+        try {
+            runnable.run();
+            return Optional.empty();
+        } catch (RuntimeException | AssertionError e) {
+            return Optional.of(e.getMessage());
+        }
+    }
+
+    static InvokableRules of(String rulesClassName, List<String> checks) {
+        return new InvokableRules(rulesClassName, checks);
+    }
+
+    static class InvocationResult {
+        private final List<String> violations = new ArrayList<>();
+
+        private void add(String violationMessage) {
+            violations.add(violationMessage);
+        }
+
+        String getMessage() {
+            return violations.stream().collect(joining(lineSeparator()));
+        }
+    }
+}

--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -1,33 +1,24 @@
 package com.societegenerale.commons.plugin.service;
 
-import com.societegenerale.commons.plugin.model.ConfigurableRule;
-import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.lang.ArchCondition;
-import com.tngtech.archunit.lang.ArchRule;
-import org.apache.commons.lang3.StringUtils;
-
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
+import com.societegenerale.commons.plugin.model.ConfigurableRule;
+import com.societegenerale.commons.plugin.service.InvokableRules.InvocationResult;
+import com.tngtech.archunit.core.domain.JavaClasses;
 
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.SRC_CLASSES_FOLDER;
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.TEST_CLASSES_FOLDER;
-import static com.societegenerale.commons.plugin.utils.ArchUtils.*;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.societegenerale.commons.plugin.utils.ArchUtils.importAllClassesInPackage;
+import static com.societegenerale.commons.plugin.utils.ReflectionUtils.loadClassWithContextClassLoader;
 
 public class RuleInvokerService {
 
     private static final String EXECUTE_METHOD_NAME = "execute";
 
-    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+    public String invokePreConfiguredRule(String ruleClassName, String projectPath) {
+        Class<?> ruleClass = loadClassWithContextClassLoader(ruleClassName);
 
-
-    public String invokePreConfiguredRule(Class<?> ruleClass, String projectPath) {
-
-        String errorMessage = StringUtils.EMPTY;
+        String errorMessage = "";
         try {
             Method method = ruleClass.getDeclaredMethod(EXECUTE_METHOD_NAME, String.class);
             method.invoke(ruleClass.newInstance(), projectPath);
@@ -37,70 +28,15 @@ public class RuleInvokerService {
         return errorMessage;
     }
 
+    public String invokeConfigurableRules(ConfigurableRule rule, String projectPath) {
 
-    public String invokeConfigurableRules(Class<?> customRuleClass, ConfigurableRule rule, String projectPath) throws ReflectiveOperationException {
-
-        StringBuilder failRuleMessagesBuilder = new StringBuilder(StringUtils.EMPTY);
-
-        Map<String, Method> archConditionReturningMethods = getAllMethodsWhichReturnAnArchCondition(customRuleClass.getDeclaredMethods());
-        Map<String, Field> archRuleFields = getAllFieldsWhichAreArchRules(customRuleClass.getDeclaredFields());
+        InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks());
 
         String packageOnRuleToApply = getPackageNameOnWhichToApplyRules(rule);
+        JavaClasses classes = importAllClassesInPackage(projectPath, packageOnRuleToApply);
 
-        List<String> ruleChecks = rule.getChecks();
-        final Map<String, Method> filteredArchConditions = new HashMap<>();
-        final Map<String, Field> filteredArchRules = new HashMap<>();
-        if (ruleChecks != null) {
-            ruleChecks.forEach(check -> {
-                if (archConditionReturningMethods.containsKey(check)) {
-                    filteredArchConditions.putAll(archConditionReturningMethods.entrySet().stream()
-                            .filter(map -> map.getKey().equals(check)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                } else if (archRuleFields.containsKey(check)) {
-                    filteredArchRules.putAll(archRuleFields.entrySet().stream()
-                            .filter(map -> map.getKey().equals(check)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-                }
-            });
-        } else {
-            filteredArchConditions.putAll(archConditionReturningMethods);
-            filteredArchRules.putAll(archRuleFields);
-        }
-
-        for (Method method : filteredArchConditions.values()) {
-            failRuleMessagesBuilder.append(invokeArchUnitCondition(projectPath, method, customRuleClass, packageOnRuleToApply));
-        }
-        for (Field field : filteredArchRules.values()) {
-            failRuleMessagesBuilder.append(invokeArchCustomRule(projectPath, field, customRuleClass, packageOnRuleToApply));
-        }
-
-        return failRuleMessagesBuilder.toString();
-    }
-
-
-    private String invokeArchCustomRule(String projectPath, Field field, Class<?> testClass, String packageOnRuleToApply)
-            throws ReflectiveOperationException {
-
-        StringBuilder errorMessageBuilder = new StringBuilder(StringUtils.EMPTY);
-        field.setAccessible(true);
-        ArchRule archRule = (ArchRule) field.get(testClass.newInstance());
-        try {
-            archRule.check(importAllClassesInPackage(projectPath, packageOnRuleToApply));
-        } catch (AssertionError e) {
-            errorMessageBuilder.append(e.getMessage()).append(LINE_SEPARATOR);
-        }
-        return errorMessageBuilder.toString();
-    }
-
-    @SuppressWarnings(value = "unchecked")
-    private String invokeArchUnitCondition(String projectPath, Method method, Class<?> ruleClass, String packageOnRuleToApply) throws ReflectiveOperationException {
-        StringBuilder errorMessageBuilder = new StringBuilder(StringUtils.EMPTY);
-        Object ruleObject = method.invoke(ruleClass.newInstance());
-        ArchCondition<JavaClass> archCondition = (ArchCondition<JavaClass>) ruleObject;
-        try {
-            classes().should(archCondition).check(importAllClassesInPackage(projectPath, packageOnRuleToApply));
-        } catch (AssertionError e) {
-            errorMessageBuilder.append(e.getMessage()).append(LINE_SEPARATOR);
-        }
-        return errorMessageBuilder.toString();
+        InvocationResult result = invokableRules.invokeOn(classes);
+        return result.getMessage();
     }
 
     private String getPackageNameOnWhichToApplyRules(ConfigurableRule rule) {
@@ -116,29 +52,4 @@ public class RuleInvokerService {
         }
         return packageNameBuilder.toString().replace(".", "/");
     }
-
-    private Map<String, Method> getAllMethodsWhichReturnAnArchCondition(Method[] methods) {
-
-        Map<String, Method> archConditionReturningMethods = new HashMap<>();
-        for (Method method : methods) {
-            if (method.getReturnType().equals(ArchCondition.class)) {
-                archConditionReturningMethods.put(method.getName(), method);
-            }
-        }
-        return archConditionReturningMethods;
-    }
-
-    private Map<String, Field> getAllFieldsWhichAreArchRules(Field[] fields) {
-
-        Map<String, Field> archRuleFields = new HashMap<>();
-
-        for (Field field : fields) {
-            if (field.getType().equals(ArchRule.class)) {
-                archRuleFields.put(field.getName(), field);
-            }
-        }
-
-        return archRuleFields;
-    }
-
 }

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionException.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionException.java
@@ -1,0 +1,7 @@
+package com.societegenerale.commons.plugin.utils;
+
+class ReflectionException extends RuntimeException {
+    ReflectionException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionException.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionException.java
@@ -1,7 +1,15 @@
 package com.societegenerale.commons.plugin.utils;
 
+import java.lang.reflect.InvocationTargetException;
+
 class ReflectionException extends RuntimeException {
-    ReflectionException(Throwable throwable) {
-        super(throwable);
+    private ReflectionException(Throwable throwable) {
+        super(throwable.getMessage(), throwable);
+    }
+
+    static ReflectionException wrap(Exception throwable) {
+        return throwable instanceof InvocationTargetException
+                ? new ReflectionException(((InvocationTargetException) throwable).getTargetException())
+                : new ReflectionException(throwable);
     }
 }

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionUtils.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionUtils.java
@@ -1,0 +1,48 @@
+package com.societegenerale.commons.plugin.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ReflectionUtils {
+    public static Class<?> loadClassWithContextClassLoader(String className) {
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new ReflectionException(e);
+        }
+    }
+
+    public static <T> T newInstance(Class<T> clazz) {
+        try {
+            Constructor<T> constructor = clazz.getConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new ReflectionException(e);
+        }
+    }
+
+    // This will always be unsafe, so we might as well make it easier for the caller
+    @SuppressWarnings("unchecked")
+    public static <T> T invoke(Method method, Object owner, Object... args) {
+        try {
+            method.setAccessible(true);
+            return (T) method.invoke(owner, args);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new ReflectionException(e);
+        }
+    }
+
+    // This will always be unsafe, so we might as well make it easier for the caller
+    @SuppressWarnings("unchecked")
+    public static <T> T getValue(Field field, Object owner) {
+        try {
+            field.setAccessible(true);
+            return (T) field.get(owner);
+        } catch (IllegalAccessException e) {
+            throw new ReflectionException(e);
+        }
+    }
+}

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionUtils.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ReflectionUtils.java
@@ -10,7 +10,7 @@ public class ReflectionUtils {
         try {
             return Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
-            throw new ReflectionException(e);
+            throw ReflectionException.wrap(e);
         }
     }
 
@@ -20,7 +20,7 @@ public class ReflectionUtils {
             constructor.setAccessible(true);
             return constructor.newInstance();
         } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-            throw new ReflectionException(e);
+            throw ReflectionException.wrap(e);
         }
     }
 
@@ -31,7 +31,7 @@ public class ReflectionUtils {
             method.setAccessible(true);
             return (T) method.invoke(owner, args);
         } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new ReflectionException(e);
+            throw ReflectionException.wrap(e);
         }
     }
 
@@ -42,7 +42,7 @@ public class ReflectionUtils {
             field.setAccessible(true);
             return (T) field.get(owner);
         } catch (IllegalAccessException e) {
-            throw new ReflectionException(e);
+            throw ReflectionException.wrap(e);
         }
     }
 }

--- a/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
@@ -24,7 +24,6 @@ import java.util.Set;
 
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ArchUnitMojoTest {

--- a/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
@@ -92,6 +92,24 @@ public class ArchUnitMojoTest {
   }
 
   @Test
+  public void shouldFailWronglyDefinedConfigurableRule() throws Exception {
+    PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");
+
+    String missingCheck = "notThere";
+    String ruleClass = MyCustomRules.class.getName();
+
+    configurableRule.addChild("rule", ruleClass);
+    configurableRule.addChild(buildChecksBlock(missingCheck));
+    pluginConfiguration.getChild("rules").getChild("configurableRules").addChild(configurableRule);
+
+    ArchUnitMojo mojo = (ArchUnitMojo) rule.configureMojo(archUnitMojo, pluginConfiguration);
+
+    assertThatExceptionOfType(MojoFailureException.class)
+        .isThrownBy(mojo::execute)
+        .withMessageContaining(String.format("The following configured checks are not present within %s: [%s]", ruleClass, missingCheck));
+  }
+
+  @Test
   public void shouldExecuteSingleConfigurableRule() throws Exception {
 
     PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");

--- a/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
@@ -88,7 +88,7 @@ public class ArchUnitMojoTest {
     ArchUnitMojo mojo = (ArchUnitMojo) rule.configureMojo(archUnitMojo, pluginConfiguration);
 
     executeAndExpectViolations(mojo,
-        expectRuleFailure("classes should  not use Powermock ")
+        expectRuleFailure("classes should not use Powermock")
             .withDetails("Favor Mockito and proper dependency injection - " + TestClassWithPowerMock.class.getName()));
   }
 
@@ -129,7 +129,7 @@ public class ArchUnitMojoTest {
 
     executeAndExpectViolations(mojo,
         expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
-        expectRuleFailure("classes should  not use Powermock ").ofAnyKind());
+        expectRuleFailure("classes should not use Powermock").ofAnyKind());
   }
 
   private void executeAndExpectViolations(ArchUnitMojo mojo, ExpectedRuleFailure... expectedRuleFailures) {

--- a/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
@@ -1,18 +1,17 @@
 package com.societegenerale.commons.plugin;
 
-
-import com.societegenerale.commons.plugin.model.Rules;
-import lombok.val;
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.collect.ImmutableSet;
+import com.societegenerale.commons.plugin.rules.MyCustomRules;
+import com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest;
+import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithPowerMock;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.project.MavenProject;
+import org.assertj.core.api.AbstractThrowableAssert;
 import org.codehaus.plexus.configuration.DefaultPlexusConfiguration;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,11 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.StringReader;
-import java.net.URL;
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.*;
@@ -43,178 +38,152 @@ public class ArchUnitMojoTest {
   @Rule
   public MojoRule rule = new MojoRule();
 
-  private Xpp3Dom pomDom;
-
   private PlexusConfiguration pluginConfiguration;
 
-  private static String defaultPom =  "<project>" +
-                                          "<build>" +
-                                              "<plugins>" +
-                                                  "<plugin>" +
-                                                  "<artifactId>arch-unit-maven-plugin</artifactId>" +
-                                                      "<configuration>" +
-                                                          "<rules>" +
-                                                            "<preConfiguredRules>" +
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoStandardStreamRuleTest</rule>" +
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoJunitAssertRuleTest</rule>" +
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoJodaTimeRuleTest</rule>" +
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest</rule>" +
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoPrefixForInterfacesRuleTest</rule>" +
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoTestIgnoreRuleTest</rule>"+
-                                                                "<rule>com.societegenerale.commons.plugin.rules.NoTestIgnoreWithoutCommentRuleTest</rule>" +
-                                                            "</preConfiguredRules>" +
-                                                            "<configurableRules>" +
-                                                                "<configurableRule>" +
-                                                                  "<rule>com.societegenerale.commons.plugin.rules.NoStandardStreamRuleTest</rule>" +
-                                                                "</configurableRule>" +
-                                                            "</configurableRules>" +
-                                                          "</rules>" +
-                                                      "</configuration>" +
-                                                  "</plugin>" +
-                                              "</plugins>" +
-                                          "</build>" +
-                                      "</project>";
-
-  String pomWithNoRule=  "<project>" +
-          "<build>" +
+  // @formatter:off
+  private static final String pomWithNoRule =
+      "<project>" +
+        "<build>" +
           "<plugins>" +
-          "<plugin>" +
-          "<artifactId>arch-unit-maven-plugin</artifactId>" +
-          "<configuration>" +
-          "<rules>" +
-          "<preConfiguredRules>" +
-          "</preConfiguredRules>" +
-          "<configurableRules>" +
-          "</configurableRules>" +
-          "</rules>" +
-          "</configuration>" +
-          "</plugin>" +
+            "<plugin>" +
+              "<artifactId>arch-unit-maven-plugin</artifactId>" +
+              "<configuration>" +
+                "<rules>" +
+                  "<preConfiguredRules></preConfiguredRules>" +
+                  "<configurableRules></configurableRules>" +
+                "</rules>" +
+              "</configuration>" +
+            "</plugin>" +
           "</plugins>" +
-          "</build>" +
-          "</project>";
-
+        "</build>" +
+      "</project>";
+  // @formatter:on
 
   @Before
   public void setUp() throws Exception {
 
-    pomDom = Xpp3DomBuilder.build(new StringReader(defaultPom));
+    pluginConfiguration = rule.extractPluginConfiguration("arch-unit-maven-plugin", Xpp3DomBuilder.build(new StringReader(pomWithNoRule)));
 
   }
 
   @Test
   public void shouldFailWhenNoRuleConfigured() throws Exception {
 
-    pluginConfiguration = rule.extractPluginConfiguration("arch-unit-maven-plugin", Xpp3DomBuilder.build(new StringReader(pomWithNoRule)));
-
     ArchUnitMojo mojo = (ArchUnitMojo) rule.configureMojo(archUnitMojo, pluginConfiguration);
 
     assertThatExceptionOfType(MojoFailureException.class)
-                      .isThrownBy(() -> mojo.execute())
-                      .withMessageContaining("Arch unit Plugin should have at least one preconfigured/configurable rule");
+        .isThrownBy(mojo::execute)
+        .withMessageContaining("Arch unit Plugin should have at least one preconfigured/configurable rule");
   }
 
   @Test
   public void shouldExecuteSinglePreconfiguredRule() throws Exception {
 
-    pluginConfiguration = rule.extractPluginConfiguration("arch-unit-maven-plugin", Xpp3DomBuilder.build(new StringReader(pomWithNoRule)));
     pluginConfiguration.getChild("projectPath").setValue("./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
 
     // add single rule
-    PlexusConfiguration preConfiguredRules=pluginConfiguration.getChild("rules").getChild("preConfiguredRules");
-    preConfiguredRules.addChild("rule","com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest");
+    PlexusConfiguration preConfiguredRules = pluginConfiguration.getChild("rules").getChild("preConfiguredRules");
+    preConfiguredRules.addChild("rule", NoPowerMockRuleTest.class.getName());
 
     ArchUnitMojo mojo = (ArchUnitMojo) rule.configureMojo(archUnitMojo, pluginConfiguration);
 
-    executeAndExpectViolations(mojo,1,"Favor Mockito and proper dependency injection");
+    executeAndExpectViolations(mojo,
+        expectRuleFailure("classes should  not use Powermock ")
+            .withDetails("Favor Mockito and proper dependency injection - " + TestClassWithPowerMock.class.getName()));
   }
 
   @Test
   public void shouldExecuteSingleConfigurableRule() throws Exception {
 
-    pluginConfiguration = rule.extractPluginConfiguration("arch-unit-maven-plugin", Xpp3DomBuilder.build(new StringReader(pomWithNoRule)));
+    PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");
 
-    PlexusConfiguration configurableRule=new DefaultPlexusConfiguration("configurableRule");
-
-    configurableRule.addChild("rule","com.societegenerale.commons.plugin.rules.MyCustomRule");
+    configurableRule.addChild("rule", MyCustomRules.class.getName());
     configurableRule.addChild(buildChecksBlock("annotatedWithTest"));
-    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase","test"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase", "test"));
 
-    PlexusConfiguration configurableRules=pluginConfiguration.getChild("rules").getChild("configurableRules");
+    PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
     configurableRules.addChild(configurableRule);
 
     ArchUnitMojo mojo = (ArchUnitMojo) rule.configureMojo(archUnitMojo, pluginConfiguration);
 
-    executeAndExpectViolations(mojo,1,"classes should be annotated with @Test");
-
+    executeAndExpectViolations(mojo,
+        expectRuleFailure("classes should be annotated with @Test").ofAnyKind());
   }
 
   @Test
   public void shouldExecuteBothConfigurableRule_and_PreConfiguredRule() throws Exception {
 
-    pluginConfiguration = rule.extractPluginConfiguration("arch-unit-maven-plugin", Xpp3DomBuilder.build(new StringReader(pomWithNoRule)));
+    PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");
 
-    PlexusConfiguration configurableRule=new DefaultPlexusConfiguration("configurableRule");
-
-    configurableRule.addChild("rule","com.societegenerale.commons.plugin.rules.MyCustomRule");
+    configurableRule.addChild("rule", "com.societegenerale.commons.plugin.rules.MyCustomRules");
     configurableRule.addChild(buildChecksBlock("annotatedWithTest"));
-    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase","test"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase", "test"));
 
-    PlexusConfiguration configurableRules=pluginConfiguration.getChild("rules").getChild("configurableRules");
+    PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
     configurableRules.addChild(configurableRule);
 
-    PlexusConfiguration preConfiguredRules=pluginConfiguration.getChild("rules").getChild("preConfiguredRules");
-    preConfiguredRules.addChild("rule","com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest");
+    PlexusConfiguration preConfiguredRules = pluginConfiguration.getChild("rules").getChild("preConfiguredRules");
+    preConfiguredRules.addChild("rule", NoPowerMockRuleTest.class.getName());
 
     ArchUnitMojo mojo = (ArchUnitMojo) rule.configureMojo(archUnitMojo, pluginConfiguration);
 
-    executeAndExpectViolations(mojo,2,"classes should be annotated with @Test","Favor Mockito and proper dependency injection" );
-
+    executeAndExpectViolations(mojo,
+        expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
+        expectRuleFailure("classes should  not use Powermock ").ofAnyKind());
   }
 
-  private void executeAndExpectViolations(ArchUnitMojo mojo ,int nbExpectedViolations, String... expectedExceptionMessages){
-
-    //would have loved to use AssertJ assertThatExceptionOfType + withMessageMatching(regex) ,
-    // but not able to find the regex to match only once..
-    // so going the dirty way..
-    boolean expectedExceptionFound=false;
-
-    try{
-      mojo.execute();
-    }
-    catch(MojoFailureException e){
-      assertThat(StringUtils.countMatches(e.toString(), "was violated")).isEqualTo(nbExpectedViolations);
-
-      assertThat(e.toString()).contains(expectedExceptionMessages);
-      expectedExceptionFound=true;
-    }
-
-    if(!expectedExceptionFound){
-      fail("was expecting an exception");
-    }
+  private void executeAndExpectViolations(ArchUnitMojo mojo, ExpectedRuleFailure... expectedRuleFailures) {
+    AbstractThrowableAssert<?, ? extends Throwable> throwableAssert = assertThatThrownBy(mojo::execute);
+    stream(expectedRuleFailures).forEach(expectedFailure -> {
+      throwableAssert.hasMessageContaining(String.format("Rule '%s' was violated", expectedFailure.ruleDescription));
+      expectedFailure.details.forEach(throwableAssert::hasMessageContaining);
+    });
   }
-
 
   private PlexusConfiguration buildApplyOnBlock(String packageName, String scope) {
 
-    PlexusConfiguration packageNameElement=new DefaultPlexusConfiguration("packageName",packageName);
-    PlexusConfiguration scopeElement=new DefaultPlexusConfiguration("scope",scope);
-    PlexusConfiguration applyOnElement=new DefaultPlexusConfiguration("applyOn");
+    PlexusConfiguration packageNameElement = new DefaultPlexusConfiguration("packageName", packageName);
+    PlexusConfiguration scopeElement = new DefaultPlexusConfiguration("scope", scope);
+    PlexusConfiguration applyOnElement = new DefaultPlexusConfiguration("applyOn");
     applyOnElement.addChild(packageNameElement);
     applyOnElement.addChild(scopeElement);
 
-    return  applyOnElement;
+    return applyOnElement;
   }
 
   private PlexusConfiguration buildChecksBlock(String... checks) {
-
-    PlexusConfiguration checksElement=new DefaultPlexusConfiguration("checks");
-
-    for(int i =0; i< checks.length ; i++){
-      PlexusConfiguration check=new DefaultPlexusConfiguration("check",checks[i]);
-      checksElement.addChild(check);
-    }
-
-    return  checksElement;
+    PlexusConfiguration checksElement = new DefaultPlexusConfiguration("checks");
+    stream(checks).map(c -> new DefaultPlexusConfiguration("check", c)).forEach(checksElement::addChild);
+    return checksElement;
   }
 
+  private static ExpectedRuleFailure.Creator expectRuleFailure(String ruleDescription) {
+    return new ExpectedRuleFailure.Creator(ruleDescription);
+  }
+
+  private static class ExpectedRuleFailure {
+    private final String ruleDescription;
+    private final Set<String> details;
+
+    private ExpectedRuleFailure(String ruleDescription, Set<String> details) {
+      this.ruleDescription = ruleDescription;
+      this.details = details;
+    }
+
+    private static class Creator {
+      private final String ruleDescription;
+
+      Creator(String ruleDescription) {
+        this.ruleDescription = ruleDescription;
+      }
+
+      ExpectedRuleFailure ofAnyKind() {
+        return withDetails();
+      }
+
+      ExpectedRuleFailure withDetails(String... detals) {
+        return new ExpectedRuleFailure(ruleDescription, ImmutableSet.copyOf(detals));
+      }
+    }
+  }
 }

--- a/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/ArchUtilsTest.java
@@ -49,7 +49,7 @@ public class ArchUtilsTest {
 				noOfClasses++;
 			}
 		}
-		assertThat(noOfClasses).isEqualTo(17);
+		assertThat(noOfClasses).isEqualTo(21);
 	}
 
 }

--- a/src/test/java/com/societegenerale/commons/plugin/rules/MyCustomRules.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/MyCustomRules.java
@@ -7,7 +7,8 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 /**
  * A dummy class with rules to configure through plugin config
  */
-public class MyCustomRule {
+@SuppressWarnings("unused")
+public class MyCustomRules {
 
     static ArchRule annotatedWithTest = classes().should().beAnnotatedWith("Test");
     static ArchRule resideInMyPackage = classes().should().resideInAPackage("myPackage");

--- a/src/test/java/com/societegenerale/commons/plugin/rules/MyCustomRules.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/MyCustomRules.java
@@ -1,5 +1,6 @@
 package com.societegenerale.commons.plugin.rules;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.lang.ArchRule;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -10,7 +11,14 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 @SuppressWarnings("unused")
 public class MyCustomRules {
 
-    static ArchRule annotatedWithTest = classes().should().beAnnotatedWith("Test");
-    static ArchRule resideInMyPackage = classes().should().resideInAPackage("myPackage");
+    static ArchRule annotatedWithTest_asField = classes().should().beAnnotatedWith("Test");
+    static ArchRule resideInMyPackage_asField = classes().should().resideInAPackage("myPackage");
 
+    static void annotatedWithTest_asMethod(JavaClasses importedClasses) {
+        classes().should().beAnnotatedWith("Test").check(importedClasses);
+    }
+
+    static void resideInMyPackage_asMethod(JavaClasses importedClasses) {
+        classes().should().resideInAPackage("myPackage").check(importedClasses);
+    }
 }

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RuleInvokerServiceTest {
@@ -19,7 +20,7 @@ public class RuleInvokerServiceTest {
     @Test
     public void shouldInvokePreConfiguredRulesMethod() {
 
-        String errorMessage = ruleInvokerService.invokePreConfiguredRule(NoStandardStreamRuleTest.class, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokePreConfiguredRule(NoStandardStreamRuleTest.class.getName(), "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
 
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
@@ -27,14 +28,15 @@ public class RuleInvokerServiceTest {
     }
 
     @Test
-    public void shouldExecute2ConfigurableRulesOnTest() throws ReflectiveOperationException {
+    public void shouldExecute2ConfigurableRulesOnTest() {
 
         ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","test");
 
+        configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(DummyCustomRule.class, configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -42,14 +44,15 @@ public class RuleInvokerServiceTest {
     }
 
     @Test
-    public void shouldExecuteOnlyTheConfiguredRule() throws ReflectiveOperationException {
+    public void shouldExecuteOnlyTheConfiguredRule() {
 
         ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","test");
 
+        configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
-        configurableRule.setChecks(Arrays.asList("annotatedWithTest"));
+        configurableRule.setChecks(singletonList("annotatedWithTest"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(DummyCustomRule.class, configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -58,15 +61,14 @@ public class RuleInvokerServiceTest {
 
 
     @Test
-    public void shouldExecuteAllRulesFromConfigurableClassByDefault() throws ReflectiveOperationException {
-
-        Class<?> ruleClass = DummyCustomRule.class;
+    public void shouldExecuteAllRulesFromConfigurableClassByDefault() {
 
         ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","main");
 
+        configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(ruleClass, configurableRule, "./target/classes/com/societegenerale/commons/plugin/rules");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/classes/com/societegenerale/commons/plugin/rules");
 
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
@@ -75,14 +77,14 @@ public class RuleInvokerServiceTest {
     }
 
     @Test
-    public void shouldExecuteAllRulesOnSpecificPackageInTest() throws ReflectiveOperationException {
-
-        Class<?> ruleClass = DummyCustomRule.class;
+    public void shouldExecuteAllRulesOnSpecificPackageInTest() {
 
         ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","test");
+
+        configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(ruleClass, configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests/specificCase");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests/specificCase");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("Rule 'classes should be annotated with @Test' was violated (1 times)");


### PR DESCRIPTION
## Summary

This PR 

* contains validation that configured checks of a `ConfigurableRule` are in fact present in the configured rule location
* adds support for ArchTest methods like JUnit support would allow
* removes support for return values of type `ArchCondition` (open for discussion!)
* changes the behavior of the class import to only import classes once per `ConfigurableRule` instead of for every check

## Context

Validation of configured checks is IMHO very important to be safe against tests broken by refactorings. Up to now an invalid check would just cause the run of the plugin to be successful, i.e. a renamed field in a custom rule class would just silently not be evaluated anymore.

Support for ArchTest methods is preferable to be consistent with ArchUnit and to make tests more powerful. Sometimes it's not feasible to declare tests as rule fields.

I've removed the support for methods returning `ArchCondition`, because I considere it of little value compared to the cost of maintaining the code. In the end each such case could AFAIK be represented by a field `classes().should(methodReturningCondition())` instead, which in turn would be more expressive. I had also noticed, that neither test nor documentation existed for this use case so far.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 

This fixes my comments from #1 
