### PR TITLE
Don't add null package to path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Removed
 
 ### Fixed
+- will now allow to use scope with empty package
 
 ## [2.1.0] - 2019-07-12
 

--- a/pom.xml
+++ b/pom.xml
@@ -269,8 +269,44 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
             </plugin>
-            
-            
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-aut-classes-to-destination</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>testResources</goal>
+                        </goals>
+
+                        <configuration>
+                            <outputDirectory>${build.directory}/aut-target/classes/com/societegenerale/aut/main</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${build.directory}/test-classes/com/societegenerale/aut/main</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-aut-test-classes-to-destination</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>testResources</goal>
+                        </goals>
+
+                        <configuration>
+                            <outputDirectory>${build.directory}/aut-target/test-classes/com/societegenerale/aut/test</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${build.directory}/test-classes/com/societegenerale/aut/test</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -54,7 +54,9 @@ public class RuleInvokerService {
             if (rule.getApplyOn().getScope() != null && "test".equals(rule.getApplyOn().getScope())) {
                 packageNameBuilder = new StringBuilder(TEST_CLASSES_FOLDER);
             }
-            packageNameBuilder.append("/").append(rule.getApplyOn().getPackageName());
+            if (rule.getApplyOn().getPackageName() != null) {
+                packageNameBuilder.append("/").append(rule.getApplyOn().getPackageName());
+            }
 
         }
         return packageNameBuilder.toString().replace(".", "/");

--- a/src/test/java/com/societegenerale/aut/main/IInterfaceWithIncorrectName.java
+++ b/src/test/java/com/societegenerale/aut/main/IInterfaceWithIncorrectName.java
@@ -1,0 +1,4 @@
+package com.societegenerale.aut.main;
+
+public interface IInterfaceWithIncorrectName {
+}

--- a/src/test/java/com/societegenerale/aut/main/InterfaceWithCorrectName.java
+++ b/src/test/java/com/societegenerale/aut/main/InterfaceWithCorrectName.java
@@ -1,0 +1,4 @@
+package com.societegenerale.aut.main;
+
+public interface InterfaceWithCorrectName {
+}

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithAdateField.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithAdateField.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.main;
 
 import java.util.Date;
 

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithJava8TimeLib.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithJava8TimeLib.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.main;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithJavaTextDateFormat.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithJavaTextDateFormat.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.main;
 
 import java.text.DateFormat;
 

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithJavaUtilGregorianCalendar.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithJavaUtilGregorianCalendar.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.main;
 
 import java.util.GregorianCalendar;
 

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithJodaTimeReferences.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithJodaTimeReferences.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.main;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;

--- a/src/test/java/com/societegenerale/aut/main/ObjectWithStandardStream.java
+++ b/src/test/java/com/societegenerale/aut/main/ObjectWithStandardStream.java
@@ -1,0 +1,8 @@
+package com.societegenerale.aut.main;
+
+public class ObjectWithStandardStream {
+
+    public void doGreatStuff() {
+        System.err.println("I don't know..");
+    }
+}

--- a/src/test/java/com/societegenerale/aut/main/TotallyGoodInterfaceName.java
+++ b/src/test/java/com/societegenerale/aut/main/TotallyGoodInterfaceName.java
@@ -1,0 +1,4 @@
+package com.societegenerale.aut.main;
+
+public interface TotallyGoodInterfaceName {
+}

--- a/src/test/java/com/societegenerale/aut/package-info.java
+++ b/src/test/java/com/societegenerale/aut/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * This package contains the AUT (application under test) which the tests run against. These files get compiled via
+ * Maven's {@code testCompile} and get afterwards copied to a certain directory.
+ * <p>
+ * {@link com.societegenerale.aut.main} gets copied to {@code target/aut-target/classes} whereas
+ * {@link com.societegenerale.aut.test} gets copied to {@code target/aut-target/test-classes}.
+ * <p>
+ * This allows the tests to run just against these set of classes and not against themselves, too.
+ */
+package com.societegenerale.aut;

--- a/src/test/java/com/societegenerale/aut/test/TestClassWhichThrowGenericException.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWhichThrowGenericException.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 public class TestClassWhichThrowGenericException {
 

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithAutowiredField.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithAutowiredField.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtClassLevel.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtClassLevel.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -6,12 +6,11 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-
-public class TestClassWithIgnoreAtMethodLevel {
+@Ignore
+public class TestClassWithIgnoreAtClassLevel {
 
     @Test
-    @Ignore
-    public void someIgnoredTestWithoutAComment() {
+    public void someTestUsingAssertJ() {
 
         assertThat(true).isTrue();
 

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtClassLevelWithComment.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtClassLevelWithComment.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtMethodLevel.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtMethodLevel.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -6,11 +6,12 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-@Ignore
-public class TestClassWithIgnoreAtClassLevel {
+
+public class TestClassWithIgnoreAtMethodLevel {
 
     @Test
-    public void someTestUsingAssertJ() {
+    @Ignore
+    public void someIgnoredTestWithoutAComment() {
 
         assertThat(true).isTrue();
 

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtMethodLevelWithComment.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithIgnoreAtMethodLevelWithComment.java
@@ -1,13 +1,15 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class TestClassWithOutJunitAsserts {
+public class TestClassWithIgnoreAtMethodLevelWithComment {
 
     @Test
+    @Ignore("here's a comment explaining why it's ignored")
     public void someTestUsingAssertJ() {
 
         assertThat(true).isTrue();

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithInjectedField.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithInjectedField.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import javax.inject.Inject;
 

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithJunit4Asserts.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithJunit4Asserts.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import org.junit.Test;
 

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithJunit5Asserts.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithJunit5Asserts.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithOutJunitAsserts.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithOutJunitAsserts.java
@@ -1,15 +1,13 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class TestClassWithIgnoreAtMethodLevelWithComment {
+public class TestClassWithOutJunitAsserts {
 
     @Test
-    @Ignore("here's a comment explaining why it's ignored")
     public void someTestUsingAssertJ() {
 
         assertThat(true).isTrue();

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithPowerMock.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithPowerMock.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/societegenerale/aut/test/TestClassWithStandardStream.java
+++ b/src/test/java/com/societegenerale/aut/test/TestClassWithStandardStream.java
@@ -1,4 +1,4 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
+package com.societegenerale.aut.test;
 
 public class TestClassWithStandardStream {
 

--- a/src/test/java/com/societegenerale/aut/test/specificCase/DummyClassToValidate.java
+++ b/src/test/java/com/societegenerale/aut/test/specificCase/DummyClassToValidate.java
@@ -1,0 +1,4 @@
+package com.societegenerale.aut.test.specificCase;
+
+public class DummyClassToValidate {
+}

--- a/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/ArchUnitMojoTest.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 import com.google.common.collect.ImmutableSet;
 import com.societegenerale.commons.plugin.rules.MyCustomRules;
 import com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithPowerMock;
+import com.societegenerale.aut.test.TestClassWithPowerMock;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -90,7 +90,7 @@ public class ArchUnitMojoTest {
   @Test
   public void shouldExecuteSinglePreconfiguredRule() throws Exception {
 
-    pluginConfiguration.getChild("projectPath").setValue("./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+    pluginConfiguration.getChild("projectPath").setValue("./target/aut-target/test-classes/com/societegenerale/aut/test");
 
     // add single rule
     PlexusConfiguration preConfiguredRules = pluginConfiguration.getChild("rules").getChild("preConfiguredRules");
@@ -134,7 +134,7 @@ public class ArchUnitMojoTest {
 
     configurableRule.addChild("rule", MyCustomRules.class.getName());
     configurableRule.addChild(buildChecksBlock(checkName));
-    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase", "test"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.aut.test.specificCase", "test"));
 
     PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
     configurableRules.addChild(configurableRule);
@@ -151,7 +151,7 @@ public class ArchUnitMojoTest {
     PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");
 
     configurableRule.addChild("rule", MyCustomRules.class.getName());
-    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase", "test"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.aut.test.specificCase", "test"));
 
     PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
     configurableRules.addChild(configurableRule);
@@ -173,7 +173,7 @@ public class ArchUnitMojoTest {
 
     configurableRule.addChild("rule", MyCustomRules.class.getName());
     configurableRule.addChild(buildChecksBlock("annotatedWithTest_asField"));
-    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.commons.plugin.rules.classesForTests.specificCase", "test"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.aut.test.specificCase", "test"));
 
     PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
     configurableRules.addChild(configurableRule);

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoAutowiredFieldTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoAutowiredFieldTestTest.java
@@ -1,7 +1,7 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithAutowiredField;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithInjectedField;
+import com.societegenerale.aut.test.TestClassWithAutowiredField;
+import com.societegenerale.aut.test.TestClassWithInjectedField;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoInjectedFieldTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoInjectedFieldTestTest.java
@@ -1,7 +1,7 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithAutowiredField;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithInjectedField;
+import com.societegenerale.aut.test.TestClassWithAutowiredField;
+import com.societegenerale.aut.test.TestClassWithInjectedField;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoJavaUtilDateRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoJavaUtilDateRuleTestTest.java
@@ -7,10 +7,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.ObjectWithAdateField;
-import com.societegenerale.commons.plugin.rules.classesForTests.ObjectWithJava8TimeLib;
-import com.societegenerale.commons.plugin.rules.classesForTests.ObjectWithJavaTextDateFormat;
-import com.societegenerale.commons.plugin.rules.classesForTests.ObjectWithJavaUtilGregorianCalendar;
+import com.societegenerale.aut.main.ObjectWithAdateField;
+import com.societegenerale.aut.main.ObjectWithJava8TimeLib;
+import com.societegenerale.aut.main.ObjectWithJavaTextDateFormat;
+import com.societegenerale.aut.main.ObjectWithJavaUtilGregorianCalendar;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoJodaTimeRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoJodaTimeRuleTestTest.java
@@ -1,7 +1,7 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.ObjectWithJava8TimeLib;
-import com.societegenerale.commons.plugin.rules.classesForTests.ObjectWithJodaTimeReferences;
+import com.societegenerale.aut.main.ObjectWithJava8TimeLib;
+import com.societegenerale.aut.main.ObjectWithJodaTimeReferences;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoJunitAssertRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoJunitAssertRuleTestTest.java
@@ -1,9 +1,8 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithJunit4Asserts;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithJunit5Asserts;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithOutJunitAsserts;
-import com.societegenerale.commons.plugin.utils.ArchUtils;
+import com.societegenerale.aut.test.TestClassWithJunit4Asserts;
+import com.societegenerale.aut.test.TestClassWithJunit5Asserts;
+import com.societegenerale.aut.test.TestClassWithOutJunitAsserts;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoPowerMockRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoPowerMockRuleTestTest.java
@@ -1,7 +1,7 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithOutJunitAsserts;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithPowerMock;
+import com.societegenerale.aut.test.TestClassWithOutJunitAsserts;
+import com.societegenerale.aut.test.TestClassWithPowerMock;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoPrefixForInterfacesRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoPrefixForInterfacesRuleTestTest.java
@@ -1,9 +1,8 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.IInterfaceWithIncorrectName;
-import com.societegenerale.commons.plugin.rules.classesForTests.InterfaceWithCorrectName;
-import com.societegenerale.commons.plugin.rules.classesForTests.TotallyGoodInterfaceName;
-import com.societegenerale.commons.plugin.utils.ArchUtils;
+import com.societegenerale.aut.main.IInterfaceWithIncorrectName;
+import com.societegenerale.aut.main.InterfaceWithCorrectName;
+import com.societegenerale.aut.main.TotallyGoodInterfaceName;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoStandardStreamRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoStandardStreamRuleTestTest.java
@@ -5,7 +5,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithStandardStream;
+import com.societegenerale.aut.test.TestClassWithStandardStream;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoTestIgnoreRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoTestIgnoreRuleTestTest.java
@@ -1,8 +1,8 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithIgnoreAtClassLevel;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithIgnoreAtMethodLevel;
-import com.societegenerale.commons.plugin.rules.classesForTests.TestClassWithOutJunitAsserts;
+import com.societegenerale.aut.test.TestClassWithIgnoreAtClassLevel;
+import com.societegenerale.aut.test.TestClassWithIgnoreAtMethodLevel;
+import com.societegenerale.aut.test.TestClassWithOutJunitAsserts;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoTestIgnoreWithoutCommentRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoTestIgnoreWithoutCommentRuleTestTest.java
@@ -1,7 +1,10 @@
 package com.societegenerale.commons.plugin.rules;
 
-import com.societegenerale.commons.plugin.rules.classesForTests.*;
-import com.societegenerale.commons.plugin.utils.ArchUtils;
+import com.societegenerale.aut.test.TestClassWithIgnoreAtClassLevel;
+import com.societegenerale.aut.test.TestClassWithIgnoreAtClassLevelWithComment;
+import com.societegenerale.aut.test.TestClassWithIgnoreAtMethodLevel;
+import com.societegenerale.aut.test.TestClassWithIgnoreAtMethodLevelWithComment;
+import com.societegenerale.aut.test.TestClassWithOutJunitAsserts;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.junit.Test;
@@ -12,8 +15,8 @@ import static org.assertj.core.api.Assertions.*;
 
 public class NoTestIgnoreWithoutCommentRuleTestTest {
 
-    private JavaClasses testClassWithIgnoreButNoComment = new ClassFileImporter().importClasses(TestClassWithIgnoreAtMethodLevel.class,TestClassWithIgnoreAtClassLevel.class);
-    private JavaClasses testClassWithIgnoreAndComment = new ClassFileImporter().importClasses(TestClassWithIgnoreAtMethodLevelWithComment.class,TestClassWithIgnoreAtClassLevelWithComment.class);
+    private JavaClasses testClassWithIgnoreButNoComment = new ClassFileImporter().importClasses(TestClassWithIgnoreAtMethodLevel.class, TestClassWithIgnoreAtClassLevel.class);
+    private JavaClasses testClassWithIgnoreAndComment = new ClassFileImporter().importClasses(TestClassWithIgnoreAtMethodLevelWithComment.class, TestClassWithIgnoreAtClassLevelWithComment.class);
     private JavaClasses testClassWithoutIgnoreAtAll= new ClassFileImporter().importClasses(TestClassWithOutJunitAsserts.class);
 
     @Test

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/IInterfaceWithIncorrectName.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/IInterfaceWithIncorrectName.java
@@ -1,4 +1,0 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
-
-public interface IInterfaceWithIncorrectName {
-}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/InterfaceWithCorrectName.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/InterfaceWithCorrectName.java
@@ -1,4 +1,0 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
-
-public interface InterfaceWithCorrectName {
-}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/TotallyGoodInterfaceName.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/TotallyGoodInterfaceName.java
@@ -1,4 +1,0 @@
-package com.societegenerale.commons.plugin.rules.classesForTests;
-
-public interface TotallyGoodInterfaceName {
-}

--- a/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/specificCase/DummyClassToValidate.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/classesForTests/specificCase/DummyClassToValidate.java
@@ -1,4 +1,0 @@
-package com.societegenerale.commons.plugin.rules.classesForTests.specificCase;
-
-public class DummyClassToValidate {
-}

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -20,7 +20,7 @@ public class RuleInvokerServiceTest {
     @Test
     public void shouldInvokePreConfiguredRulesMethod() {
 
-        String errorMessage = ruleInvokerService.invokePreConfiguredRule(NoStandardStreamRuleTest.class.getName(), "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokePreConfiguredRule(NoStandardStreamRuleTest.class.getName(), "./target/aut-target/");
 
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
@@ -37,7 +37,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
         configurableRule.setSkip(true);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isEmpty();
     }
 
@@ -50,7 +50,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -66,7 +66,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(singletonList("annotatedWithTest"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -82,7 +82,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/classes/com/societegenerale/commons/plugin/rules");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
 
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
@@ -98,7 +98,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/test-classes/com/societegenerale/commons/plugin/rules/classesForTests/specificCase");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/test-classes/com/societegenerale/aut/test/specificCase");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("Rule 'classes should be annotated with @Test' was violated (1 times)");

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -42,6 +42,21 @@ public class RuleInvokerServiceTest {
     }
 
     @Test
+    public void shouldExecuteConfigurableRuleWithNoPackageProvided_OnlyOnClassesOfScope() {
+
+        ApplyOn applyOn = new ApplyOn(null,"test");
+
+        configurableRule.setRule(DummyCustomRule.class.getName());
+        configurableRule.setApplyOn(applyOn);
+        configurableRule.setChecks(Arrays.asList("annotatedWithTest"));
+
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
+        assertThat(errorMessage).isNotEmpty();
+        assertThat(errorMessage).doesNotContain("Class <com.societegenerale.aut.main.ObjectWithAdateField>");
+        assertThat(errorMessage).contains("Class <com.societegenerale.aut.test.TestClassWithOutJunitAsserts>");
+    }
+
+    @Test
     public void shouldExecute2ConfigurableRulesOnTest() {
 
         ApplyOn applyOn = new ApplyOn("com.societegenerale.commons.plugin.rules","test");


### PR DESCRIPTION
## Summary

The path now doesn't get null appended if you provide a scope without a `packageName`.

## Details

If you don't specify the packageName, null gets appended which later leads to a check against a non existing package and then the code defaults to use all classes. With that behavior you effectively can't use the scope without giving a package.

## Context

Suppose you'd like to check all classes, I'd not add a package-name. But I like the ability to specify the scope of the classes to check. With the current behavior this is not possible because null gets added to the path which makes the path invalid.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.

What about tests? I'd like to add a test, but the current tests mix test-classes and test-classes of the AUT. I'd consider restructuring src/test/ before adding a test for this problem, so that you can separate test classes from test classes of the AUT.

If not, would you like to make the broken method package private to be able to test it directly?

I was unsure which of both you prefer (or if you have a third possibility) -just give me a hint and I can add a test. Thx

- [ ] Documentation has been updated accordingly to this PR

## Related issue : 

No issue exists for this as far as I can see.