### PR TITLE
Use recommended way to log.

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/ArchUnitMojo.java
@@ -1,5 +1,11 @@
 package com.societegenerale.commons.plugin;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.model.Rules;
 import com.societegenerale.commons.plugin.service.RuleInvokerService;
@@ -11,12 +17,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 import static java.lang.System.lineSeparator;
 import static java.net.URLClassLoader.newInstance;
@@ -58,7 +58,7 @@ public class ArchUnitMojo extends AbstractMojo {
         return rules;
     }
 
-    private RuleInvokerService ruleInvokerService = new RuleInvokerService();
+    private RuleInvokerService ruleInvokerService ;
 
     private static final String PREFIX_ARCH_VIOLATION_MESSAGE = "ArchUnit Maven plugin reported architecture failures listed below :";
 
@@ -76,6 +76,8 @@ public class ArchUnitMojo extends AbstractMojo {
         String ruleFailureMessage;
         try {
             configureContextClassLoader();
+
+            ruleInvokerService = new RuleInvokerService(getLog());
 
             ruleFailureMessage = invokeRules();
         } catch (final Exception e) {
@@ -109,7 +111,7 @@ public class ArchUnitMojo extends AbstractMojo {
         }
 
         for (ConfigurableRule rule : rules.getConfigurableRules()) {
-            String errorMessage = ruleInvokerService.invokeConfigurableRules(getLog(), rule, projectPath);
+            String errorMessage = ruleInvokerService.invokeConfigurableRules(rule, projectPath);
             errorListBuilder.append(prepareErrorMessageForRuleFailures(rule.getRule(), errorMessage));
         }
 

--- a/src/main/java/com/societegenerale/commons/plugin/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/ArchUnitMojo.java
@@ -11,8 +11,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -31,8 +29,6 @@ import static java.net.URLClassLoader.newInstance;
  */
 @Mojo(name = "arch-test", requiresDependencyResolution = ResolutionScope.TEST)
 public class ArchUnitMojo extends AbstractMojo {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ArchUnitMojo.class);
-
     /**
      * Skips all processing performed by this plugin.
      *
@@ -69,7 +65,7 @@ public class ArchUnitMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoFailureException {
         if (skip) {
-            LOGGER.info("Skipping execution.");
+            getLog().info("Skipping execution.");
             return;
         }
 
@@ -113,7 +109,7 @@ public class ArchUnitMojo extends AbstractMojo {
         }
 
         for (ConfigurableRule rule : rules.getConfigurableRules()) {
-            String errorMessage = ruleInvokerService.invokeConfigurableRules(rule, projectPath);
+            String errorMessage = ruleInvokerService.invokeConfigurableRules(getLog(), rule, projectPath);
             errorListBuilder.append(prepareErrorMessageForRuleFailures(rule.getRule(), errorMessage));
         }
 

--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -4,16 +4,25 @@ import java.lang.reflect.Method;
 
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.service.InvokableRules.InvocationResult;
+import com.societegenerale.commons.plugin.utils.ArchUtils;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import org.apache.maven.plugin.logging.Log;
 
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.SRC_CLASSES_FOLDER;
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.TEST_CLASSES_FOLDER;
-import static com.societegenerale.commons.plugin.utils.ArchUtils.importAllClassesInPackage;
 import static com.societegenerale.commons.plugin.utils.ReflectionUtils.loadClassWithContextClassLoader;
 
 public class RuleInvokerService {
     private static final String EXECUTE_METHOD_NAME = "execute";
+
+    private Log log;
+
+    private ArchUtils archUtils;
+
+    public RuleInvokerService(Log log) {
+        this.log=log;
+        archUtils =new ArchUtils(log);
+    }
 
     public String invokePreConfiguredRule(String ruleClassName, String projectPath) {
         Class<?> ruleClass = loadClassWithContextClassLoader(ruleClassName);
@@ -28,7 +37,7 @@ public class RuleInvokerService {
         return errorMessage;
     }
 
-    public String invokeConfigurableRules(Log log, ConfigurableRule rule, String projectPath) {
+    public String invokeConfigurableRules(ConfigurableRule rule, String projectPath) {
         if(rule.isSkip()) {
             if(log.isInfoEnabled()) {
                 log.info("Skipping rule " + rule.getRule());
@@ -39,7 +48,7 @@ public class RuleInvokerService {
         InvokableRules invokableRules = InvokableRules.of(rule.getRule(), rule.getChecks());
 
         String packageOnRuleToApply = getPackageNameOnWhichToApplyRules(rule);
-        JavaClasses classes = importAllClassesInPackage(projectPath, packageOnRuleToApply);
+        JavaClasses classes = archUtils.importAllClassesInPackage(projectPath, packageOnRuleToApply);
 
         InvocationResult result = invokableRules.invokeOn(classes);
         return result.getMessage();

--- a/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
+++ b/src/main/java/com/societegenerale/commons/plugin/service/RuleInvokerService.java
@@ -5,8 +5,7 @@ import java.lang.reflect.Method;
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.service.InvokableRules.InvocationResult;
 import com.tngtech.archunit.core.domain.JavaClasses;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.maven.plugin.logging.Log;
 
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.SRC_CLASSES_FOLDER;
 import static com.societegenerale.commons.plugin.rules.ArchRuleTest.TEST_CLASSES_FOLDER;
@@ -14,8 +13,6 @@ import static com.societegenerale.commons.plugin.utils.ArchUtils.importAllClasse
 import static com.societegenerale.commons.plugin.utils.ReflectionUtils.loadClassWithContextClassLoader;
 
 public class RuleInvokerService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RuleInvokerService.class);
-
     private static final String EXECUTE_METHOD_NAME = "execute";
 
     public String invokePreConfiguredRule(String ruleClassName, String projectPath) {
@@ -31,9 +28,11 @@ public class RuleInvokerService {
         return errorMessage;
     }
 
-    public String invokeConfigurableRules(ConfigurableRule rule, String projectPath) {
+    public String invokeConfigurableRules(Log log, ConfigurableRule rule, String projectPath) {
         if(rule.isSkip()) {
-            LOGGER.info("Skipping rule {}", rule.getRule());
+            if(log.isInfoEnabled()) {
+                log.info("Skipping rule " + rule.getRule());
+            }
             return "";
         }
 

--- a/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
+++ b/src/main/java/com/societegenerale/commons/plugin/utils/ArchUtils.java
@@ -3,30 +3,36 @@ package com.societegenerale.commons.plugin.utils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import com.societegenerale.commons.plugin.service.RuleInvokerService;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.maven.plugin.logging.Log;
 
 /**
  * Created by agarg020917 on 11/17/2017.
  */
 public class ArchUtils {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RuleInvokerService.class);
+    private static Log log;
 
-    private ArchUtils() {
-        throw new UnsupportedOperationException();
+    public ArchUtils(Log log) {
+        this.log=log;
     }
 
     public static JavaClasses importAllClassesInPackage(String path, String classFolder) {
+
+        //not great design, but since all the rules need to call this, it's very convenient to keep this method static
+        if(log==null){
+            throw new IllegalStateException("please make sure you instantiate "+ArchUtils.class+" with a proper "+Log.class+" before calling this static method");
+        }
+
         Path classesPath = Paths.get(path + classFolder);
+
         if (classesPath.toFile().exists()) {
             return new ClassFileImporter().importPath(classesPath);
         }
         else{
-            LOGGER.warn("classpath {} doesn't exist : loading all classes from root, ie {}",classesPath.toFile(),path);
+            StringBuilder warnMessage=new StringBuilder("classpath ").append(classesPath.toFile()).append("doesn't exist : loading all classes from root, ie ").append(path);
+            log.warn(warnMessage.toString());
             return new ClassFileImporter().importPath(Paths.get(path));
         }
 

--- a/src/test/java/com/societegenerale/commons/plugin/rules/NoPublicFieldRuleTestTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/rules/NoPublicFieldRuleTestTest.java
@@ -1,5 +1,8 @@
 package com.societegenerale.commons.plugin.rules;
 
+import com.societegenerale.commons.plugin.utils.ArchUtils;
+import org.apache.maven.plugin.testing.SilentLog;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -9,6 +12,12 @@ public class NoPublicFieldRuleTestTest {
 	String pathObjectWithNoPublicField = "./target/aut-target/test-classes/com/societegenerale/aut/test/ObjectWithNoNonStaticPublicField.class";
 
 	String pathObjectWithPublicField = "./target/aut-target/test-classes/com/societegenerale/aut/test/ObjectWithPublicField.class";
+
+	@Before
+	public void setup(){
+		//in the normal lifecycle, ArchUtils is instantiated, which enables a static field there to be initialized
+		ArchUtils archUtils=new ArchUtils(new SilentLog());
+	}
 
 	@Test(expected = AssertionError.class)
 	public void shouldThrowViolations() {

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -4,6 +4,8 @@ import com.societegenerale.commons.plugin.model.ApplyOn;
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.rules.NoStandardStreamRuleTest;
 import com.societegenerale.commons.plugin.rules.classesForTests.DummyCustomRule;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.testing.SilentLog;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -16,6 +18,8 @@ public class RuleInvokerServiceTest {
     RuleInvokerService ruleInvokerService = new RuleInvokerService();
 
     ConfigurableRule configurableRule = new ConfigurableRule();
+
+    private Log testLogger = new SilentLog();
 
     @Test
     public void shouldInvokePreConfiguredRulesMethod() {
@@ -37,7 +41,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
         configurableRule.setSkip(true);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isEmpty();
     }
 
@@ -50,7 +54,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(Arrays.asList("annotatedWithTest"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).doesNotContain("Class <com.societegenerale.aut.main.ObjectWithAdateField>");
         assertThat(errorMessage).contains("Class <com.societegenerale.aut.test.TestClassWithOutJunitAsserts>");
@@ -65,7 +69,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -81,7 +85,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(singletonList("annotatedWithTest"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -97,7 +101,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
 
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
@@ -113,7 +117,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/test-classes/com/societegenerale/aut/test/specificCase");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/test-classes/com/societegenerale/aut/test/specificCase");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("Rule 'classes should be annotated with @Test' was violated (1 times)");

--- a/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/service/RuleInvokerServiceTest.java
@@ -1,5 +1,7 @@
 package com.societegenerale.commons.plugin.service;
 
+import java.util.Arrays;
+
 import com.societegenerale.commons.plugin.model.ApplyOn;
 import com.societegenerale.commons.plugin.model.ConfigurableRule;
 import com.societegenerale.commons.plugin.rules.NoStandardStreamRuleTest;
@@ -8,14 +10,12 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.junit.Test;
 
-import java.util.Arrays;
-
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RuleInvokerServiceTest {
 
-    RuleInvokerService ruleInvokerService = new RuleInvokerService();
+    RuleInvokerService ruleInvokerService = new RuleInvokerService(new SilentLog());
 
     ConfigurableRule configurableRule = new ConfigurableRule();
 
@@ -41,7 +41,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
         configurableRule.setSkip(true);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isEmpty();
     }
 
@@ -54,7 +54,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(Arrays.asList("annotatedWithTest"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).doesNotContain("Class <com.societegenerale.aut.main.ObjectWithAdateField>");
         assertThat(errorMessage).contains("Class <com.societegenerale.aut.test.TestClassWithOutJunitAsserts>");
@@ -69,7 +69,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(Arrays.asList("annotatedWithTest","resideInMyPackage"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -85,7 +85,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setApplyOn(applyOn);
         configurableRule.setChecks(singletonList("annotatedWithTest"));
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("classes should be annotated with @Test");
@@ -101,7 +101,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/");
 
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
@@ -117,7 +117,7 @@ public class RuleInvokerServiceTest {
         configurableRule.setRule(DummyCustomRule.class.getName());
         configurableRule.setApplyOn(applyOn);
 
-        String errorMessage = ruleInvokerService.invokeConfigurableRules(testLogger, configurableRule, "./target/aut-target/test-classes/com/societegenerale/aut/test/specificCase");
+        String errorMessage = ruleInvokerService.invokeConfigurableRules(configurableRule, "./target/aut-target/test-classes/com/societegenerale/aut/test/specificCase");
         assertThat(errorMessage).isNotEmpty();
         assertThat(errorMessage).contains("Architecture Violation");
         assertThat(errorMessage).contains("Rule 'classes should be annotated with @Test' was violated (1 times)");


### PR DESCRIPTION
See https://maven.apache.org/plugin-developers/common-bugs.html#Retrieving_the_Mojo_Logger

Using the Mojo's logger seems to be a better option than slf4j.

## Summary

Changes the SLF4J logger to the logger provided by the AbstractMojo.

## Details

[Guide to Developing Java Plugins](https://maven.apache.org/guides/plugin/guide-java-plugin-development.html):
> The getLog method (defined in AbstractMojo) returns a log4j-like logger object which allows plugins to create messages at levels of "debug", "info", "warn", and "error". This logger is the accepted means to display information to the user. Please have a look at the section Retrieving the Mojo Logger for a hint on its proper usage.

## Context

I'm not sure which problem this fixes, but it looks better to not define the logger in the plugin.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR


## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->
