### PR TITLE
Using maven project variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 ### Changed
-- Now getting the main and test values in MavenScopePathProviderfrom Maven project variable, instead of hardcoding it
+- Now getting the main and test values in MavenScopePathProvider from Maven project variable, instead of hardcoding it
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Now getting the main and test values in MavenScopePathProviderfrom Maven project variable, instead of hardcoding it
 
 ### Deprecated
 

--- a/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
@@ -83,7 +83,7 @@ public class ArchUnitMojo extends AbstractMojo {
         try {
             configureContextClassLoader();
 
-            ruleInvokerService = new RuleInvokerService(new MavenLogAdapter(getLog()), new MavenScopePathProvider(), excludedPaths);
+            ruleInvokerService = new RuleInvokerService(new MavenLogAdapter(getLog()), new MavenScopePathProvider(mavenProject), excludedPaths);
 
             ruleFailureMessage = ruleInvokerService.invokeRules(coreRules);
         } catch (final Exception e) {

--- a/src/main/java/com/societegenerale/commons/plugin/maven/MavenScopePathProvider.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/MavenScopePathProvider.java
@@ -14,22 +14,11 @@ public class MavenScopePathProvider implements ScopePathProvider {
 
     @Override
     public RootClassFolder getMainClassesPath() {
-
-        if (project == null) {
-            return new RootClassFolder("target/classes");
-        } else {
-            return new RootClassFolder(project.getBuild().getOutputDirectory());
-        }
+        return new RootClassFolder(project.getBuild().getOutputDirectory());
     }
 
     @Override
     public RootClassFolder getTestClassesPath() {
-
-        if (project == null) {
-            return new RootClassFolder("target/test-classes");
-        } else {
-            return new RootClassFolder(project.getBuild().getTestOutputDirectory());
-        }
-
+        return new RootClassFolder(project.getBuild().getTestOutputDirectory());
     }
 }

--- a/src/main/java/com/societegenerale/commons/plugin/maven/MavenScopePathProvider.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/MavenScopePathProvider.java
@@ -2,16 +2,34 @@ package com.societegenerale.commons.plugin.maven;
 
 import com.societegenerale.commons.plugin.model.RootClassFolder;
 import com.societegenerale.commons.plugin.service.ScopePathProvider;
+import org.apache.maven.project.MavenProject;
 
 public class MavenScopePathProvider implements ScopePathProvider {
 
+    private final MavenProject project;
+
+    public MavenScopePathProvider(MavenProject project) {
+        this.project = project;
+    }
+
     @Override
     public RootClassFolder getMainClassesPath() {
-        return new RootClassFolder("target/classes");
+
+        if (project == null) {
+            return new RootClassFolder("target/classes");
+        } else {
+            return new RootClassFolder(project.getBuild().getOutputDirectory());
+        }
     }
 
     @Override
     public RootClassFolder getTestClassesPath() {
-        return new RootClassFolder("target/test-classes");
+
+        if (project == null) {
+            return new RootClassFolder("target/test-classes");
+        } else {
+            return new RootClassFolder(project.getBuild().getTestOutputDirectory());
+        }
+
     }
 }

--- a/src/test/java/com/societegenerale/commons/plugin/maven/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/maven/ArchUnitMojoTest.java
@@ -13,6 +13,7 @@ import com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.apache.maven.model.Build;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.MojoRule;
@@ -79,6 +80,12 @@ public class ArchUnitMojoTest {
 
   @Before
   public void setUp() throws Exception {
+
+    Build mockBuild = mock(Build.class);
+
+    when(mavenProject.getBuild()).thenReturn(mockBuild);
+    when(mockBuild.getOutputDirectory()).thenReturn("target/classes");
+    when(mockBuild.getTestOutputDirectory()).thenReturn("target/test-classes");
 
     pluginConfiguration = mojoRule.extractPluginConfiguration("arch-unit-maven-plugin", Xpp3DomBuilder.build(new StringReader(pomWithNoRule)));
   }
@@ -234,7 +241,6 @@ public class ArchUnitMojoTest {
     File testPom = new File(getBasedir(), "target/test-classes/unit/plugin-config.xml");
     ArchUnitMojo archUnitMojo = (ArchUnitMojo) mojoRule.lookupMojo("arch-test", testPom);
 
-    MavenProject mavenProject = mock(MavenProject.class);
     when(mavenProject.getPackaging()).thenReturn("pom");
 
     mojoRule.setVariableValueToObject(archUnitMojo, "mavenProject", mavenProject);


### PR DESCRIPTION
instead of hardcoding values in MavenScopePathProvider, getting the values for main and test paths from an injected Maven Project : a properly configured Maven project that defines specific outputDirectory and testOutputDirectory will work 