### PR TITLE
Add nofailonerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ So your config would become something like :
   <artifactId>arch-unit-maven-plugin</artifactId>
   <version>2.7.2</version>
   <configuration>
+
+    <!-- optional - you can avoid build fail if there is issue. True to avoid build failure, default is false -->
+    <noFailOnError>true</noFailOnError>
     
     <!-- optional - you can exclude classes that have a path containing any of the mentioned paths -->
     <excludedPaths>

--- a/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
@@ -58,6 +58,9 @@ public class ArchUnitMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.directory}")
     private String projectBuildDir;
 
+    @Parameter(property = "noFailOnError", defaultValue = "false")
+    private boolean noFailOnError;
+
     public MavenRules getRules() {
         return rules;
     }
@@ -96,7 +99,11 @@ public class ArchUnitMojo extends AbstractMojo {
         }
 
         if (!StringUtils.isEmpty(ruleFailureMessage)) {
-            throw new MojoFailureException(PREFIX_ARCH_VIOLATION_MESSAGE + ruleFailureMessage);
+            if(!noFailOnError) {
+                throw new MojoFailureException(PREFIX_ARCH_VIOLATION_MESSAGE + ruleFailureMessage);
+            }
+
+            getLog().info(PREFIX_ARCH_VIOLATION_MESSAGE + ruleFailureMessage);
         }
     }
 


### PR DESCRIPTION
## Summary

Add an option to avoid build failure when there is issue. The option is **noFailOnError**.

## Details

Add an option in **ArchUnitMojo** called **noFailOnError** with default value **false**. The default value is **false** to continue with default behavior by default and it does not force user to change his configuration if he upgrades the plugin.
Errors are still log as _Log.info_. Info is used because if Error or Warn, only first line is consider as Error or Warn by terminal in IDE.

## Context

The option can be used in a deployment system when we don't want application crash when there is issue but we want to continue the process.

## Checklist:

- [ ] I've added tests for my code. => Test fail before I do the code. I do not know why.
- [X] Documentation has been updated accordingly to this PR


## Related issue : 
It does not fit exactly with #18 but it ignores errors.
