### PR TITLE
Allow ArchConfiguration properties to be set from Maven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- PR #51 - Allow ArchConfiguration properties to be set from Maven
+
 ### Changed
 
 ### Deprecated

--- a/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
@@ -4,12 +4,15 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.societegenerale.commons.plugin.Log;
 import com.societegenerale.commons.plugin.maven.model.MavenRules;
 import com.societegenerale.commons.plugin.model.Rules;
 import com.societegenerale.commons.plugin.service.RuleInvokerService;
+import com.tngtech.archunit.ArchConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -61,6 +64,9 @@ public class ArchUnitMojo extends AbstractMojo {
     @Parameter(property = "noFailOnError", defaultValue = "false")
     private boolean noFailOnError;
 
+    @Parameter
+    private Map<String, String> properties = new HashMap<>();
+
     public MavenRules getRules() {
         return rules;
     }
@@ -86,6 +92,13 @@ public class ArchUnitMojo extends AbstractMojo {
             getLog().debug("module packaging is 'pom', so skipping execution");
             return;
         }
+
+        if (!properties.isEmpty()) {
+            getLog().debug("configuring ArchUnit properties");
+            final ArchConfiguration archConfiguration = ArchConfiguration.get();
+            properties.forEach(archConfiguration::setProperty);
+        }
+
         String ruleFailureMessage;
         try {
             configureContextClassLoader();


### PR DESCRIPTION
## Summary

Allow `ArchConfiguration` properties to be set in a Maven style, including module-specific property expansion.

## Details

- `ArchUnitMojo` now has a `<properties>` configuration that can be configured via Maven:
  ```xml
      <plugin>
        <groupId>com.societegenerale.commons</groupId>
        <artifactId>arch-unit-maven-plugin</artifactId>
        <configuration>
          <properties>
            <freeze.store.default.allowStoreCreation>true</freeze.store.default.allowStoreCreation>
            <freeze.store.default.path>${project.basedir}/src/archunit/</freeze.store.default.path>
          </properties>
          <rules>
          ...
          </rules>
        </configuration>
      </plugin>
  ```
- `ArchConfiguration` properties are updated for each module, using standard property expansion so that values can be set using module-specific properties.
- No `archunit.properties` file is written.

## Context

This provides an alternative to the workaround documented in #37, without requiring each rule to modify `ArchConfiguration`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->
- #37