### PR TITLE
adding support for 'pom' packaging

### DIFF
--- a/src/main/java/com/societegenerale/commons/plugin/maven/model/MavenApplyOn.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/model/MavenApplyOn.java
@@ -11,15 +11,19 @@ public class MavenApplyOn {
   @Parameter(property = "scope")
   private String scope;
 
+  @Parameter(property = "aggregator", defaultValue = "false")
+  private boolean aggregator;
+
   //default constructor is required at runtime
   public MavenApplyOn() {
 
   }
 
   //convenience constructor when calling from unit tests
-  public MavenApplyOn(String packageName, String scope) {
+  public MavenApplyOn(String packageName, String scope, boolean aggregator) {
     this.packageName = packageName;
     this.scope = scope;
+    this.aggregator = aggregator;
   }
 
   public String getPackageName() {
@@ -30,6 +34,10 @@ public class MavenApplyOn {
     return scope;
   }
 
+  public boolean getAggregator() {
+    return aggregator;
+  }
+
   public void setPackageName(String packageName) {
     this.packageName = packageName;
   }
@@ -38,7 +46,11 @@ public class MavenApplyOn {
     this.scope = scope;
   }
 
+  public void setAggregator(boolean aggregator) {
+    this.aggregator = aggregator;
+  }
+
   public ApplyOn toCoreApplyOn() {
-      return new ApplyOn(packageName,scope);
+    return new ApplyOn(packageName,scope);
   }
 }

--- a/src/main/java/com/societegenerale/commons/plugin/maven/model/MavenRules.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/model/MavenRules.java
@@ -2,6 +2,7 @@ package com.societegenerale.commons.plugin.maven.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import com.societegenerale.commons.plugin.model.Rules;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -29,8 +30,16 @@ public class MavenRules {
 
         return new Rules(preConfiguredRules,
                 configurableRules.stream()
-                                 .map(e -> e.toCoreConfigurableRule())
-                                 .collect(toList()));
+                        .map(e -> e.toCoreConfigurableRule())
+                        .collect(toList()));
+    }
+
+    public Rules toCoreRules(boolean isApplyOnAggregator) {
+        return new Rules(isApplyOnAggregator ? List.of() : preConfiguredRules,
+                configurableRules.stream()
+                        .filter(configurableRule -> Optional.ofNullable(configurableRule.getApplyOn()).map(MavenApplyOn::getAggregator).orElse(false) == isApplyOnAggregator)
+                        .map(MavenConfigurableRule::toCoreConfigurableRule)
+                        .toList());
     }
 
     public List<String> getPreConfiguredRules() {

--- a/src/test/java/com/societegenerale/commons/plugin/maven/AbstractArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/maven/AbstractArchUnitMojoTest.java
@@ -17,82 +17,90 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 abstract class AbstractArchUnitMojoTest
 {
     protected static ExpectedRuleFailure.Creator expectRuleFailure(String ruleDescription) {
-      return new ExpectedRuleFailure.Creator(ruleDescription);
+        return new ExpectedRuleFailure.Creator(ruleDescription);
     }
 
     protected String getBasedir() {
-      String basedir = System.getProperty("basedir");
+        String basedir = System.getProperty("basedir");
 
-      if (basedir == null) {
-        basedir = new File("").getAbsolutePath();
-      }
+        if (basedir == null) {
+            basedir = new File("").getAbsolutePath();
+        }
 
-      return basedir;
+        return basedir;
     }
 
     protected void executeAndExpectViolations(ArchUnitMojo mojo, ExpectedRuleFailure... expectedRuleFailures) {
-      AbstractThrowableAssert<?, ? extends Throwable> throwableAssert = assertThatThrownBy(mojo::execute);
-      stream(expectedRuleFailures).forEach(expectedFailure -> {
-        throwableAssert.hasMessageContaining(String.format("Rule '%s' was violated", expectedFailure.ruleDescription));
-        expectedFailure.details.forEach(throwableAssert::hasMessageContaining);
-      });
-      throwableAssert.has(exactNumberOfViolatedRules(expectedRuleFailures.length));
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert = assertThatThrownBy(mojo::execute);
+        stream(expectedRuleFailures).forEach(expectedFailure -> {
+            throwableAssert.hasMessageContaining(String.format("Rule '%s' was violated", expectedFailure.ruleDescription));
+            expectedFailure.details.forEach(throwableAssert::hasMessageContaining);
+        });
+        throwableAssert.has(exactNumberOfViolatedRules(expectedRuleFailures.length));
     }
 
     private Condition<Throwable> exactNumberOfViolatedRules(final int number) {
-      return new Condition<Throwable>("exactly " + number + " violated rules") {
-        @Override
-        public boolean matches(Throwable throwable) {
-          Matcher matcher = Pattern.compile("Rule '.*' was violated").matcher(throwable.getMessage());
-          int numberOfOccurrences = 0;
-          while (matcher.find()) {
-            numberOfOccurrences++;
-          }
-          return numberOfOccurrences == number;
-        }
-      };
+        return new Condition<Throwable>("exactly " + number + " violated rules") {
+            @Override
+            public boolean matches(Throwable throwable) {
+                Matcher matcher = Pattern.compile("Rule '.*' was violated").matcher(throwable.getMessage());
+                int numberOfOccurrences = 0;
+                while (matcher.find()) {
+                    numberOfOccurrences++;
+                }
+                return numberOfOccurrences == number;
+            }
+        };
     }
 
     protected PlexusConfiguration buildApplyOnBlock(String packageName, String scope) {
 
-      PlexusConfiguration packageNameElement = new DefaultPlexusConfiguration("packageName", packageName);
-      PlexusConfiguration scopeElement = new DefaultPlexusConfiguration("scope", scope);
-      PlexusConfiguration applyOnElement = new DefaultPlexusConfiguration("applyOn");
-      applyOnElement.addChild(packageNameElement);
-      applyOnElement.addChild(scopeElement);
-
-      return applyOnElement;
+        return buildApplyOnBlock(packageName, scope, false);
     }
 
+    protected PlexusConfiguration buildApplyOnBlock(String packageName, String scope, Boolean aggregator) {
+
+        PlexusConfiguration packageNameElement = new DefaultPlexusConfiguration("packageName", packageName);
+        PlexusConfiguration scopeElement = new DefaultPlexusConfiguration("scope", scope);
+        PlexusConfiguration aggregatorElement = new DefaultPlexusConfiguration("aggregator", aggregator.toString());
+        PlexusConfiguration applyOnElement = new DefaultPlexusConfiguration("applyOn");
+        applyOnElement.addChild(packageNameElement);
+        applyOnElement.addChild(scopeElement);
+        applyOnElement.addChild(aggregatorElement);
+
+        return applyOnElement;
+    }
+
+
     protected PlexusConfiguration buildChecksBlock(String... checks) {
-      PlexusConfiguration checksElement = new DefaultPlexusConfiguration("checks");
-      stream(checks).map(c -> new DefaultPlexusConfiguration("check", c)).forEach(checksElement::addChild);
-      return checksElement;
+        PlexusConfiguration checksElement = new DefaultPlexusConfiguration("checks");
+        stream(checks).map(c -> new DefaultPlexusConfiguration("check", c)).forEach(checksElement::addChild);
+        return checksElement;
     }
 
     public static class ExpectedRuleFailure {
-      private final String ruleDescription;
-      private final Set<String> details;
-
-      private ExpectedRuleFailure(String ruleDescription, Set<String> details) {
-        this.ruleDescription = ruleDescription;
-        this.details = details;
-      }
-
-      public static class Creator {
         private final String ruleDescription;
+        private final Set<String> details;
 
-        Creator(String ruleDescription) {
-          this.ruleDescription = ruleDescription;
+        private ExpectedRuleFailure(String ruleDescription, Set<String> details) {
+            this.ruleDescription = ruleDescription;
+            this.details = details;
         }
 
-        ExpectedRuleFailure ofAnyKind() {
-          return withDetails();
-        }
+        public static class Creator {
+            private final String ruleDescription;
 
-        ExpectedRuleFailure withDetails(String... detals) {
-          return new ExpectedRuleFailure(ruleDescription, ImmutableSet.copyOf(detals));
+            Creator(String ruleDescription) {
+                this.ruleDescription = ruleDescription;
+            }
+
+            ExpectedRuleFailure ofAnyKind() {
+                return withDetails();
+            }
+
+            ExpectedRuleFailure withDetails(String... detals) {
+                return new ExpectedRuleFailure(ruleDescription, ImmutableSet.copyOf(detals));
+            }
         }
-      }
     }
 }

--- a/src/test/java/com/societegenerale/commons/plugin/maven/ArchUnitMojoTest.java
+++ b/src/test/java/com/societegenerale/commons/plugin/maven/ArchUnitMojoTest.java
@@ -1,8 +1,5 @@
 package com.societegenerale.commons.plugin.maven;
 
-import java.io.File;
-import java.io.StringReader;
-
 import com.societegenerale.aut.test.TestClassWithPowerMock;
 import com.societegenerale.commons.plugin.rules.MyCustomAndDummyRules;
 import com.societegenerale.commons.plugin.rules.NoPowerMockRuleTest;
@@ -28,6 +25,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import java.io.File;
+import java.io.StringReader;
+import java.util.List;
 
 import static com.tngtech.junit.dataprovider.DataProviders.testForEach;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,21 +60,21 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
 
   // @formatter:off
   private static final String pomWithNoRule =
-      "<project>" +
-        "<build>" +
-          "<plugins>" +
-            "<plugin>" +
-              "<artifactId>arch-unit-maven-plugin</artifactId>" +
-              "<configuration>" +
-                "<rules>" +
+          "<project>" +
+                  "<build>" +
+                  "<plugins>" +
+                  "<plugin>" +
+                  "<artifactId>arch-unit-maven-plugin</artifactId>" +
+                  "<configuration>" +
+                  "<rules>" +
                   "<preConfiguredRules></preConfiguredRules>" +
                   "<configurableRules></configurableRules>" +
-                "</rules>" +
-              "</configuration>" +
-            "</plugin>" +
-          "</plugins>" +
-        "</build>" +
-      "</project>";  // @formatter:on
+                  "</rules>" +
+                  "</configuration>" +
+                  "</plugin>" +
+                  "</plugins>" +
+                  "</build>" +
+                  "</project>";  // @formatter:on
 
   @Before
   public void setUp() throws Exception {
@@ -93,8 +94,8 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
 
     assertThatExceptionOfType(MojoFailureException.class)
-        .isThrownBy(mojo::execute)
-        .withMessageContaining("Arch unit Plugin should have at least one preconfigured/configurable rule");
+            .isThrownBy(mojo::execute)
+            .withMessageContaining("Arch unit Plugin should have at least one preconfigured/configurable rule");
   }
 
   @Test
@@ -107,8 +108,8 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
 
     executeAndExpectViolations(mojo,
-        expectRuleFailure("classes should not use Powermock")
-            .withDetails("Favor Mockito and proper dependency injection - " + TestClassWithPowerMock.class.getName()));
+            expectRuleFailure("classes should not use Powermock")
+                    .withDetails("Favor Mockito and proper dependency injection - " + TestClassWithPowerMock.class.getName()));
   }
 
   @Test
@@ -127,12 +128,9 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     mojo.setLog(log);
     mojo.execute();
 
-    verify(log, times(1)).warn(
-            "ArchUnit Maven plugin reported architecture failures listed below :Rule Violated - " + NoPowerMockRuleTest.class.getName()
-                    + System.lineSeparator() +
-                    "java.lang.AssertionError: Architecture Violation [Priority: MEDIUM] - Rule 'classes should not use Powermock' was violated (1 times):"
-                    + System.lineSeparator() +
-                    "Favor Mockito and proper dependency injection - " + TestClassWithPowerMock.class.getName() + System.lineSeparator());
+    verify(log, times(1)).info("ArchUnit Maven plugin reported architecture failures listed below :Rule Violated - " + NoPowerMockRuleTest.class.getName() + System.lineSeparator() +
+            "java.lang.AssertionError: Architecture Violation [Priority: MEDIUM] - Rule 'classes should not use Powermock' was violated (1 times):" + System.lineSeparator() +
+            "Favor Mockito and proper dependency injection - " + TestClassWithPowerMock.class.getName() + System.lineSeparator());
   }
 
   @Test
@@ -149,8 +147,8 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
 
     assertThatExceptionOfType(MojoFailureException.class)
-        .isThrownBy(mojo::execute)
-        .withMessageContaining(String.format("The following configured checks are not present within %s: [%s]", ruleClass, missingCheck));
+            .isThrownBy(mojo::execute)
+            .withMessageContaining(String.format("The following configured checks are not present within %s: [%s]", ruleClass, missingCheck));
   }
 
   @DataProvider
@@ -174,7 +172,7 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
 
     executeAndExpectViolations(mojo,
-        expectRuleFailure("classes should be annotated with @Test").ofAnyKind());
+            expectRuleFailure("classes should be annotated with @Test").ofAnyKind());
   }
 
   @Test
@@ -191,10 +189,10 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
 
     executeAndExpectViolations(mojo,
-        expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
-        expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
-        expectRuleFailure("classes should reside in a package 'myPackage'").ofAnyKind(),
-        expectRuleFailure("classes should reside in a package 'myPackage'").ofAnyKind()
+            expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
+            expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
+            expectRuleFailure("classes should reside in a package 'myPackage'").ofAnyKind(),
+            expectRuleFailure("classes should reside in a package 'myPackage'").ofAnyKind()
     );
   }
 
@@ -216,8 +214,33 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
     ArchUnitMojo mojo = (ArchUnitMojo) mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
 
     executeAndExpectViolations(mojo,
-        expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
-        expectRuleFailure("classes should not use Powermock").ofAnyKind());
+            expectRuleFailure("classes should be annotated with @Test").ofAnyKind(),
+            expectRuleFailure("classes should not use Powermock").ofAnyKind());
+  }
+
+  @Test
+  public void shouldExecuteConfigurableRuleOnAggregator() throws Exception {
+    PlexusConfiguration configurableRule = new DefaultPlexusConfiguration("configurableRule");
+
+    configurableRule.addChild("rule", MyCustomAndDummyRules.class.getName());
+    configurableRule.addChild(buildChecksBlock("annotatedWithTest_asField"));
+    configurableRule.addChild(buildApplyOnBlock("com.societegenerale.aut.test.specificCase", "test", true));
+
+    PlexusConfiguration configurableRules = pluginConfiguration.getChild("rules").getChild("configurableRules");
+    configurableRules.addChild(configurableRule);
+
+    File testPom = new File(getBasedir(), "target/test-classes/unit/plugin-config.xml");
+    ArchUnitMojo archUnitMojo = (ArchUnitMojo) mojoRule.lookupMojo("arch-test", testPom);
+
+    MavenProject pomMavenProject = mock(MavenProject.class);
+    when(pomMavenProject.getPackaging()).thenReturn("pom");
+    when(pomMavenProject.getCollectedProjects()).thenReturn(List.of(mavenProject));
+
+    mojoRule.setVariableValueToObject(archUnitMojo, "mavenProject", pomMavenProject);
+    mojoRule.configureMojo(archUnitMojo, pluginConfiguration);
+
+    executeAndExpectViolations(archUnitMojo,
+            expectRuleFailure("classes should be annotated with @Test").ofAnyKind());
   }
 
   @Test
@@ -245,9 +268,9 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
   }
 
   @Test
-  public void shouldSkipIfPackagingIsPom() throws Exception {
+  public void shouldNotApplyPreConfiguredRuleIfPackagingIsPom() throws Exception {
     InterceptingLog interceptingLogger = new InterceptingLog(
-        mojoRule.getContainer().lookup(LoggerManager.class).getLoggerForComponent(Mojo.ROLE));
+            mojoRule.getContainer().lookup(LoggerManager.class).getLoggerForComponent(Mojo.ROLE));
 
     File testPom = new File(getBasedir(), "target/test-classes/unit/plugin-config.xml");
     ArchUnitMojo archUnitMojo = (ArchUnitMojo) mojoRule.lookupMojo("arch-test", testPom);
@@ -259,7 +282,7 @@ public class ArchUnitMojoTest extends AbstractArchUnitMojoTest
 
     assertThatCode(() -> archUnitMojo.execute()).doesNotThrowAnyException();
 
-    assertThat(interceptingLogger.debugLogs).containsExactly("module packaging is 'pom', so skipping execution");
+    assertThat(interceptingLogger.debugLogs).containsExactly("no rule apply for projects");
   }
 
   @Test


### PR DESCRIPTION
## Summary

New configuration property on applyOn to support run archunit test on 'pom' packaging.

## Details

Use new plugin core version in this [PR](https://github.com/societe-generale/arch-unit-build-plugin-core/pull/83) to support run archunit test on 'pom' packaging

## Context

Currently the plugin skip 'pom' packaging so we cannot run project layer check which requires the classes in all sub-modules presented.

## Checklist:

- [x] I've added tests for my code.
- [ ] Documentation has been updated accordingly to this PR -> will updated based on your oppinion


## Related issue : 
https://github.com/societe-generale/arch-unit-maven-plugin/issues/55
