### PR TITLE
add configuration switch to disable fallback to root directory (3.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ for details on the (very simple) logic.
 Since v2.8.0, we can exclude something like `generated-sources`, even if the code ends up in the same package(S) as the regular code. See the
 discussion in https://github.com/societe-generale/arch-unit-maven-plugin/pull/44 for more details
 
+## Disable fallback for wrongly configured paths
+
+When no class files have been found using the configured paths, all folders of the current maven module are scanned for analysable classes. This could be a 
+problem in multi-module projects when some modules do not contain analyzable code (e.g. for packaging of web applications).
+
+This behavior can be disabled by setting the optional `fallbackToRootDirectory` element of the configuration to `false`. 
+
 ## Contribute !
 
 If you want to make changes in the Maven specific behavior, don't hesitate to open on issue on this repository and/or create a pull request.

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <mockito.version>3.1.0</mockito.version>
         <jaxb.version>2.3.3</jaxb.version>
 
-        <arch-unit-build-plugin-core.version>3.1.1-SNAPSHOT</arch-unit-build-plugin-core.version>
+        <arch-unit-build-plugin-core.version>3.1.1</arch-unit-build-plugin-core.version>
 
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
         <generated.test.source.directory>${project.basedir}/target/generated-test-sources/test-annotations</generated.test.source.directory>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
             <name>Vincent Fuchs</name>
             <email>vincent.fuchs@gmail.com</email>
         </developer>
-        
+
         <developer>
 			<id>FanJups</id>
 			<name>Fanon Jupkwo</name>
 			<email>jupsfan@gmail.com</email>
   		</developer>
-        
+
     </developers>
 
     <licenses>
@@ -55,7 +55,7 @@
         <mockito.version>3.1.0</mockito.version>
         <jaxb.version>2.3.3</jaxb.version>
 
-        <arch-unit-build-plugin-core.version>3.0.0</arch-unit-build-plugin-core.version>
+        <arch-unit-build-plugin-core.version>3.1.1-SNAPSHOT</arch-unit-build-plugin-core.version>
 
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
         <generated.test.source.directory>${project.basedir}/target/generated-test-sources/test-annotations</generated.test.source.directory>

--- a/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
+++ b/src/main/java/com/societegenerale/commons/plugin/maven/ArchUnitMojo.java
@@ -64,6 +64,9 @@ public class ArchUnitMojo extends AbstractMojo {
     @Parameter(property = "noFailOnError", defaultValue = "false")
     private boolean noFailOnError;
 
+    @Parameter(defaultValue = "true")
+    private boolean fallbackToRootDirectory = true;
+
     @Parameter
     private Map<String, String> properties = new HashMap<>();
 
@@ -104,7 +107,7 @@ public class ArchUnitMojo extends AbstractMojo {
             configureContextClassLoader();
             final Log mavenLogAdapter = new MavenLogAdapter(getLog());
 
-            ruleInvokerService = new RuleInvokerService(mavenLogAdapter, new MavenScopePathProvider(mavenProject), excludedPaths, projectBuildDir);
+            ruleInvokerService = new RuleInvokerService(mavenLogAdapter, new MavenScopePathProvider(mavenProject), excludedPaths, projectBuildDir, fallbackToRootDirectory);
 
             ruleFailureMessage = ruleInvokerService.invokeRules(coreRules);
         } catch (final Exception e) {


### PR DESCRIPTION
## Summary

Skip analysis for projects without source files

## Details

If no source files are found in a module of a multi module project, no analysis should be done (e.g. in modules which just assemble war files or docker images). Therefor a the configuration property `fallbackToRootDirectory` is added to disable the current default behavior.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Which environnment is/are impacted ? -->

Feature is needed in bigger Maven multi module projects.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've added tests for my code.
- [x] Documentation has been updated accordingly to this PR


## Related issue : 
<!-- If it fixes an open issue, please link to the issue here. -->

closes #66 